### PR TITLE
[JENKINS-11117] Look up project for each build.

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -98,8 +98,8 @@ public class TriggerBuilder extends Builder {
                 List<AbstractProject> projectList = config.getProjectList(env);
                 
                 if(!projectList.isEmpty()){
-                    AbstractProject p = projectList.get(n);
                         for (Future<AbstractBuild> f : e.getValue()) {
+                        AbstractProject p = projectList.get(n);
                         try {
                             listener.getLogger().println("Waiting for the completion of " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
                             AbstractBuild b = f.get();


### PR DESCRIPTION
This is a lower risk fix than https://github.com/jenkinsci/parameterized-trigger-plugin/pull/8 - as it just reorders two lines of code to what I assume the _intended_ ordering was. :-)
