### PR TITLE
Allows a Groovy script to evaluate if the trigger must be executed or not

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
 
     <dependencies>
         <dependency>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy</artifactId>
+          <version>1.8.4</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <version>1.25</version>
@@ -40,6 +46,15 @@
     </dependencies>
 
     <build>
+      <pluginManagement>
+        <plugins>
+                <plugin> 
+                        <groupId>org.apache.maven.plugins</groupId> 
+                        <artifactId>maven-compiler-plugin</artifactId> 
+                        <version>2.3.1</version> 
+                </plugin>
+        </plugins> 
+      </pluginManagement>
       <plugins>
         <plugin>
           <!-- make sure our code doesn't have 1.6 dependencies except where we know it -->
@@ -54,13 +69,21 @@
               <configuration>
                 <signature>
                   <groupId>org.jvnet.animal-sniffer</groupId>
-                  <artifactId>java1.5</artifactId>
+                  <artifactId>java1.6</artifactId>
                   <version>1.0</version>
                 </signature>
               </configuration>
             </execution>
           </executions>
         </plugin>
+        <plugin> 
+           <groupId>org.apache.maven.plugins</groupId> 
+           <artifactId>maven-compiler-plugin</artifactId> 
+           <configuration> 
+                   <source>1.6</source> 
+                   <target>1.6</target> 
+           </configuration> 
+        </plugin> 
       </plugins>
     </build>
 

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -50,36 +50,53 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
 
 	private String projects;
 	private final ResultCondition condition;
+	private final String script;
 	private boolean triggerWithNoParameters;
 
     // the list of projects to build is computed in getProjectList() ; this method
     // is actually invoked twice (when in a build step), so let's cache its result
     private transient List<AbstractProject> projectList;
 
-    public BuildTriggerConfig(String projects, ResultCondition condition,
+    public BuildTriggerConfig(String projects, ResultCondition condition, String script,
             boolean triggerWithNoParameters, List<AbstractBuildParameterFactory> configFactories, List<AbstractBuildParameters> configs) {
         this.projects = projects;
         this.condition = condition;
+        this.script = script;
         this.triggerWithNoParameters = triggerWithNoParameters;
         this.configFactories = configFactories;
         this.configs = Util.fixNull(configs);
     }
 
     @DataBoundConstructor
+    public BuildTriggerConfig(String projects, ResultCondition condition, String script,
+            boolean triggerWithNoParameters, List<AbstractBuildParameters> configs) {
+        this(projects, condition, script, triggerWithNoParameters, null, configs);
+    }
+
+    public BuildTriggerConfig(String projects, ResultCondition condition,
+            boolean triggerWithNoParameters, List<AbstractBuildParameterFactory> configFactories, List<AbstractBuildParameters> configs) {
+    	this(projects, condition, null, triggerWithNoParameters, configFactories, configs);
+    }
+
     public BuildTriggerConfig(String projects, ResultCondition condition,
             boolean triggerWithNoParameters, List<AbstractBuildParameters> configs) {
-        this(projects, condition, triggerWithNoParameters, null, configs);
+        this(projects, condition, null, triggerWithNoParameters, null, configs);
     }
 
 	public BuildTriggerConfig(String projects, ResultCondition condition,
 			AbstractBuildParameters... configs) {
-		this(projects, condition, false, null, Arrays.asList(configs));
+		this(projects, condition, null, false, null, Arrays.asList(configs));
+	}
+
+	public BuildTriggerConfig(String projects, ResultCondition condition, String script,
+			AbstractBuildParameters... configs) {
+		this(projects, condition, script, false, null, Arrays.asList(configs));
 	}
 
 	public BuildTriggerConfig(String projects, ResultCondition condition,
             List<AbstractBuildParameterFactory> configFactories,
 			AbstractBuildParameters... configs) {
-		this(projects, condition, false, configFactories, Arrays.asList(configs));
+		this(projects, condition, null, false, configFactories, Arrays.asList(configs));
 	}
 
 	public List<AbstractBuildParameters> getConfigs() {
@@ -96,6 +113,10 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
 
 	public ResultCondition getCondition() {
 		return condition;
+	}
+	
+	public String getScript() {
+		return script;
 	}
 
 	public boolean getTriggerWithNoParameters() {

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
@@ -8,6 +8,9 @@
   <f:entry title="${%Trigger when build is}" field="condition">
     <f:enum>${it.displayName}</f:enum>
   </f:entry>
+  <f:entry title="Trigger when script is true" field="script"> 
+     <f:textarea value="${instance.script}" /> 
+  </f:entry>
   <f:entry title="${%Trigger build without parameters}" field="triggerWithNoParameters" >
 	<f:checkbox checked="${instance.triggerWithNoParameters}"/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/help-script.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/help-script.html
@@ -1,0 +1,17 @@
+<div>
+	Groovy script that checks additional conditions on the build. Leave the script empty
+	to disable any script execution.
+	<p>
+			The script takes several parameters:
+			<ul>
+					<li><code>build</code> - <a href="http://javadoc.jenkins-ci.org/hudson/model/AbstractBuild.html">Hudson Build</a></li>
+					<li><code>listener</code> - <a href="http://javadoc.jenkins-ci.org/hudson/model/TaskListener.html">Task listener</a>, useful to log information</li>
+			</ul>
+	</p>
+	<p>
+		For example, to enable this trigger only at night, between 21:00 and 6:00, use the following script:
+		<pre>hour = Calendar.instance.get(Calendar.HOUR_OF_DAY)
+listener.logger.println "Executing script at ${hour}H"
+(hour >= 21 || hour < 6)</pre>
+	</p>
+</div>

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/ScriptTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/ScriptTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Tom Huybrechts
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.parameterizedtrigger.test;
+
+import hudson.model.Project;
+import hudson.model.Queue;
+import hudson.plugins.parameterizedtrigger.BuildTrigger;
+import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
+import hudson.plugins.parameterizedtrigger.PredefinedBuildParameters;
+import hudson.plugins.parameterizedtrigger.ResultCondition;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+/**
+ * Test of scripting the triggering.
+ *
+ */
+public class ScriptTest extends HudsonTestCase {
+
+    public void testTriggerByScript_onSuccess_scriptReturnsTrue() throws Exception {
+        Project projectA = createFreeStyleProject("projectA");
+        Project projectB = createFreeStyleProject("projectB");
+        projectB.setQuietPeriod(1);
+
+        schedule(projectA, projectB, ResultCondition.SUCCESS, "true");
+        assertEquals(1, projectB.getLastBuild().getNumber());
+    }
+
+    public void testTriggerByScript_onSuccess_scriptReturnsFalse() throws Exception {
+        Project projectA = createFreeStyleProject("projectA");
+        Project projectB = createFreeStyleProject("projectB");
+        projectB.setQuietPeriod(1);
+
+        schedule(projectA, projectB, ResultCondition.SUCCESS, "false");
+        assertNull(projectB.getLastBuild());
+    }
+
+    public void testTriggerByScript_onFailure_scriptReturnsTrue() throws Exception {
+        Project projectA = createFreeStyleProject("projectA");
+        projectA.getBuildersList().add(new FailureBuilder());
+        Project projectB = createFreeStyleProject("projectB");
+        projectB.setQuietPeriod(1);
+
+        schedule(projectA, projectB, ResultCondition.SUCCESS, "true");
+        assertNull(projectB.getLastBuild());
+    }
+
+    public void testTriggerByScript_onFailure_scriptReturnsFalse() throws Exception {
+        Project projectA = createFreeStyleProject("projectA");
+        projectA.getBuildersList().add(new FailureBuilder());
+        Project projectB = createFreeStyleProject("projectB");
+        projectB.setQuietPeriod(1);
+
+        schedule(projectA, projectB, ResultCondition.SUCCESS, "false");
+        assertNull(projectB.getLastBuild());
+    }
+
+    private void schedule(Project projectA, Project projectB, ResultCondition condition, String script)
+            throws IOException, InterruptedException, ExecutionException {
+        projectA.getPublishersList().replace(new BuildTrigger(new BuildTriggerConfig("projectB", condition, script, new PredefinedBuildParameters(""))));
+        hudson.rebuildDependencyGraph();
+        projectA.scheduleBuild2(0).get();
+        Queue.Item q = hudson.getQueue().getItem(projectB);
+        if (q != null) q.getFuture().get();
+    }
+    
+}


### PR DESCRIPTION
Hi all,

The feature this commit introduces is the ability to enter a Groovy script as a triggering criteria. If the script returns true, then the trigger is executed - if not, nothing is triggered.

Note that this introduces a dependency on Java 6 (to support the external script engine).

Regards,
Damien.
