### PR TITLE
Show Subprojects without using the dependency Graph

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction.java
@@ -24,11 +24,11 @@
 
 package hudson.plugins.parameterizedtrigger;
 
-import java.util.Map;
-
 import hudson.EnvVars;
-import hudson.model.EnvironmentContributingAction;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.EnvironmentContributingAction;
+import jenkins.model.Jenkins;
 
 public class BuildInfoExporterAction implements EnvironmentContributingAction {
   public static final String JOB_NAME_VARIABLE = "LAST_TRIGGERED_JOB_NAME";
@@ -36,11 +36,13 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
 
   private String buildName;
   private int buildNumber;
+  private final AbstractBuild<?, ?> parentBuild;
 
-  public BuildInfoExporterAction(String buildName, int buildNumber) {
+  public BuildInfoExporterAction(String buildName, int buildNumber, AbstractBuild<?,?> parentBuild) {
     super();
     this.buildName = buildName;
     this.buildNumber = buildNumber;
+        this.parentBuild = parentBuild;
   }
 
   public String getIconFileName() {
@@ -60,4 +62,15 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
     env.put(JOB_NAME_VARIABLE, buildName);
     env.put(BUILD_NUMBER_VARIABLE_PREFIX + buildName, Integer.toString(buildNumber));
   }
+
+    public boolean isFirst() {
+        return parentBuild.getAction(BuildInfoExporterAction.class) == this;
+    }
+
+    public AbstractBuild<?,?> getTriggeredBuild() {
+        AbstractProject<?, ? extends AbstractBuild<?,?>> project =
+                Jenkins.getInstance().getItemByFullName(buildName, AbstractProject.class);
+        return project.getBuildByNumber(buildNumber);
+    }
+
 }

--- a/src/main/java/hudson/plugins/parameterizedtrigger/SubProjectsAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/SubProjectsAction.java
@@ -1,0 +1,52 @@
+package hudson.plugins.parameterizedtrigger;
+
+import com.google.common.collect.ImmutableList;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+
+import java.util.List;
+
+public class SubProjectsAction implements Action {
+
+    private AbstractProject<?,?> project;
+    private List<BlockableBuildTriggerConfig> configs;
+
+    public SubProjectsAction(AbstractProject<?,?> project, List<BlockableBuildTriggerConfig> configs) {
+        this.project = project;
+        this.configs = configs;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+
+    public List<BlockableBuildTriggerConfig> getConfigs() {
+        return configs;
+    }
+
+    public List<SubProjectsAction> getSubProjectActions() {
+        if (isFirst()) {
+            return project.getActions(SubProjectsAction.class);
+        }
+        return ImmutableList.of();
+    }
+
+    public AbstractProject<?,?> getProject() {
+        return project;
+    }
+
+    private boolean isFirst() {
+        return project.getAction(SubProjectsAction.class) == this;
+    }
+}

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggeredBuildsAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggeredBuildsAction.java
@@ -1,0 +1,35 @@
+package hudson.plugins.parameterizedtrigger;
+
+import com.google.common.collect.Lists;
+import hudson.model.AbstractBuild;
+
+import java.util.List;
+
+public class TriggeredBuildsAction {
+    private AbstractBuild<?, ?> parentBuild;
+
+    public TriggeredBuildsAction(AbstractBuild<?,?> parentBuild) {
+        super();
+        this.parentBuild = parentBuild;
+    }
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getDisplayName() {
+        return null;
+    }
+
+    public String getUrlName() {
+        return null;
+    }
+
+    public List<AbstractBuild<?, ?>> getTriggeredBuilds() {
+        List<BuildInfoExporterAction> actions = parentBuild.getActions(BuildInfoExporterAction.class);
+        List<AbstractBuild<?,?>> triggeredBuilds = Lists.newArrayList();
+        for (BuildInfoExporterAction action : actions) {
+            triggeredBuilds.add(action.getTriggeredBuild());
+        }
+        return triggeredBuilds;
+    }
+}

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
@@ -1,0 +1,25 @@
+package hudson.plugins.parameterizedtrigger.BuildInfoExporterAction;
+
+def f=namespace(lib.FormTagLib)
+def j=namespace(lib.JenkinsTagLib)
+def l=namespace(lib.LayoutTagLib)
+
+if (my.first) {
+    h2("Subproject Builds");
+}
+
+def build = my.triggeredBuild
+
+ul(style:"list-style-type: none;") {
+    li {
+        a(href:"${rootURL}/${build.project.url}", class:"model-link") {
+            text(build.project.displayName)
+        }
+        a(href:"${rootURL}/${build.url}", class:"model-link") {
+            img(src:"${imagesURL}/16x16/${build.buildStatusUrl}",
+                    alt:"${build.iconColor.description}", height:"16", width:"16")
+            text(build.displayName)
+        }
+    }
+}
+

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/SubProjectsAction/jobMain.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/SubProjectsAction/jobMain.groovy
@@ -1,0 +1,26 @@
+package hudson.plugins.parameterizedtrigger.SubProjectsAction
+
+import hudson.Functions
+
+def f=namespace(lib.FormTagLib)
+def j=namespace(lib.JenkinsTagLib)
+def l=namespace(lib.LayoutTagLib)
+
+def actions = my.subProjectActions
+if (!actions.empty) {
+    h2("Subprojects")
+    my.subProjectActions.each { action ->
+        ul(style:"list-style-type: none;") {
+            action.configs.each { config ->
+                config.getProjectList(my.project.parent, null).each { project ->
+                    if (Functions.hasPermission(project, project.READ)) {
+                        li {
+                            j.jobLink(job:project)
+                            text("(${config.block == null ? 'non-blocking' : 'blocking'})")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/TriggeredBuildsAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/TriggeredBuildsAction/summary.groovy
@@ -1,0 +1,29 @@
+package hudson.plugins.parameterizedtrigger.TriggeredBuildsAction
+
+def f=namespace(lib.FormTagLib)
+def j=namespace(lib.JenkinsTagLib)
+def l=namespace(lib.LayoutTagLib)
+
+def builds = my.triggeredBuilds
+
+if (builds.empty) {
+    return
+}
+
+h2("Subproject Builds");
+
+ul(style:"list-style-type: none;") {
+    builds.each({ build ->
+    li {
+        a(href:"${rootURL}/${build.project.url}", class:"model-link") {
+            text(build.project.displayName)
+        }
+        a(href:"${rootURL}/${build.url}", class:"model-link") {
+            img(src:"${imagesURL}/16x16/${build.buildStatusUrl}",
+                    alt:"${build.iconColor.description}", height:"16", width:"16")
+            text(build.displayName)
+        }
+    }
+    })
+}
+


### PR DESCRIPTION
Blocking Build-Triggers (aka SubProjects) should not use the DependencyGraph. Our usecase is that we have set of CI-Jobs with dependencies between them (one Job uses a jar from another one). Then we have a release job which waits for all these Jobs to complete (via TriggerBuilder & Block).
Moreover, for the CI-Version, we want our jobs to wait while upstream projects are building. If the SubProjects are added to the DependencyGraph, then they will wait until the release Job is complete which in turn waits until the CI-Jobs are complete. Therefore, we have a deadlock and nothing happens. See also [JENKINS-5184].
