### PR TITLE
[FIXED JENKINS-8916] Allowing same type of parameter for triggered build more than once seems redundant

### DIFF
--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/config.jelly
@@ -35,6 +35,7 @@ THE SOFTWARE.
   <f:block>
     <f:hetero-list name="configs" hasHeader="true"
                    descriptors="${descriptor.getBuilderConfigDescriptors()}"
+                   oneEach="true"
                    items="${instance.configs}"
                    addCaption="${%Add Parameters}"
     />

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
@@ -15,6 +15,7 @@
   <f:block>
     <f:hetero-list name="configs" hasHeader="true"
                    descriptors="${descriptor.getBuilderConfigDescriptors()}"
+                   oneEach="true"
                    items="${instance.configs}"
                    addCaption="${%Add Parameters}"
     />


### PR DESCRIPTION
It uses the new "oneEach" attribute of the "f:hetero-list" jelly tag. Jenkins core version 1.463 is required to make it work, but it's backwards compatible so no dependency on 1.463 is introduced.
