### PR TITLE
https://issues.jenkins-ci.org/browse/JENKINS-11556

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -121,7 +121,6 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
      *      The container with which to resolve relative project names.
      */
 	public List<AbstractProject> getProjectList(ItemGroup context, EnvVars env) {
-        if(projectList == null) {
             projectList = new ArrayList<AbstractProject>();
 
             // expand variables if applicable
@@ -135,7 +134,6 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
             }
 
             projectList.addAll(Items.fromNameList(context, projectNames.toString(), AbstractProject.class));
-        }
 		return projectList;
 	}
 


### PR DESCRIPTION
Removing caching of projectList to prevent building of improper jobs.

https://issues.jenkins-ci.org/browse/JENKINS-11556
