### PR TITLE
capture build environment to expand variables in triggered job parameters

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/AbstractBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/AbstractBuildParameters.java
@@ -1,11 +1,9 @@
 package hudson.plugins.parameterizedtrigger;
 
+import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Action;
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-import hudson.model.Hudson;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
@@ -14,6 +12,20 @@ public abstract class AbstractBuildParameters extends AbstractDescribableImpl<Ab
 
     public abstract Action getAction(AbstractBuild<?,?> build, TaskListener listener)
             throws IOException, InterruptedException, DontTriggerException;
+
+    /**
+     * Retrieve the build environment from the upstream build
+     */
+    public EnvVars getEnvironment(AbstractBuild<?,?> build, TaskListener listener)
+            throws IOException, InterruptedException {
+
+        CapturedEnvironmentAction capture = build.getAction(CapturedEnvironmentAction.class);
+        if (capture != null) {
+            return capture.getCapturedEnvironment();
+        } else {
+            return build.getEnvironment(listener);
+        }
+    }
 
     public static class DontTriggerException extends Exception {}
 }

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -1,5 +1,6 @@
 package hudson.plugins.parameterizedtrigger;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
@@ -52,12 +53,17 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer, MatrixA
 	@Override @SuppressWarnings("deprecation")
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
 			BuildListener listener) throws InterruptedException, IOException {
-		// In Hudson 1.341+ builds will be triggered via DependencyGraph
-		if (canDeclare(build.getProject())) return true;
+        if (canDeclare(build.getProject())) {
+            // job will get triggered by dependency graph, so we have to capture buildEnvironment NOW before
+            // hudson.model.AbstractBuild.AbstractBuildExecution#cleanUp is called and reset
+            EnvVars env = build.getEnvironment(listener);
+            build.addAction(new CapturedEnvironmentAction(env));
+        } else {
+            for (BuildTriggerConfig config : configs) {
+                config.perform(build, launcher, listener);
+            }
+        }
 
-		for (BuildTriggerConfig config : configs) {
-			config.perform(build, launcher, listener);
-		}
 
 		return true;
 	}
@@ -73,7 +79,8 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer, MatrixA
 	}
 
 	private boolean canDeclare(AbstractProject owner) {
-		// Inner class added in Hudson 1.341
+        // In Hudson 1.341+ builds will be triggered via DependencyGraph
+        // Inner class added in Hudson 1.341
         String ownerClassName = owner.getClass().getName();
 		return DependencyGraph.class.getClasses().length > 0
                         // See HUDSON-5679 -- dependency graph is also not used when triggered from a promotion

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.concurrent.Future;
 

--- a/src/main/java/hudson/plugins/parameterizedtrigger/CapturedEnvironmentAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/CapturedEnvironmentAction.java
@@ -1,0 +1,21 @@
+package hudson.plugins.parameterizedtrigger;
+
+import hudson.EnvVars;
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class CapturedEnvironmentAction extends InvisibleAction {
+
+    private final EnvVars env;
+
+    public CapturedEnvironmentAction(EnvVars env) {
+        this.env = env;
+    }
+
+    public EnvVars getCapturedEnvironment() {
+        return env;
+    }
+}

--- a/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
@@ -32,7 +32,7 @@ public class FileBuildParameters extends AbstractBuildParameters {
 	public Action getAction(AbstractBuild<?,?> build, TaskListener listener)
 			throws IOException, InterruptedException {
 
-		EnvVars env = build.getEnvironment(listener);
+		EnvVars env = getEnvironment(build, listener);
 
 		String resolvedPropertiesFile = env.expand(propertiesFile);
 		FilePath f = build.getWorkspace().child(resolvedPropertiesFile);

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
@@ -31,7 +31,7 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 	public Action getAction(AbstractBuild<?,?> build, TaskListener listener)
 			throws IOException, InterruptedException {
 
-		EnvVars env = build.getEnvironment(listener);
+		EnvVars env = getEnvironment(build, listener);
 
 		Properties p = new Properties();
 		p.load(new StringInputStream(properties));

--- a/src/main/java/hudson/plugins/parameterizedtrigger/matrix/MatrixSubsetBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/matrix/MatrixSubsetBuildParameters.java
@@ -30,7 +30,7 @@ public class MatrixSubsetBuildParameters extends AbstractBuildParameters {
 
     @Override
 	public Action getAction(AbstractBuild<?,?> build, TaskListener listener) throws IOException, InterruptedException {
-        return new MatrixSubsetAction(build.getEnvironment(listener).expand(filter));
+        return new MatrixSubsetAction(getEnvironment(build, listener).expand(filter));
 	}
 
 	@Extension


### PR DESCRIPTION
as downstream job is triggered by dependency graph, build.getEnvironment is called to compute parameters AFTER AbstractBuild.clean has reset buildEnvironment, so that node properties and others are lost. 

This pull request add a build action to capture the build environment, and uses it to compute parameters, as it does when using the "legacy mode" to directly schedule the downstream jobs from publisher
