### PR TITLE
[FIXED JENKINS-15520] Added a checkbox to allow dependancy to be declare...

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
@@ -28,20 +28,30 @@ import java.util.concurrent.Future;
 public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
     private final BlockingBehaviour block;
     public boolean buildAllNodesWithLabel;
+    private boolean dependencyDeclared = true;
 
     public BlockableBuildTriggerConfig(String projects, BlockingBehaviour block, List<AbstractBuildParameters> configs) {
         super(projects, ResultCondition.ALWAYS, false, configs);
         this.block = block;
+        this.dependencyDeclared = dependencyDeclared;
     }
 
-    @DataBoundConstructor
     public BlockableBuildTriggerConfig(String projects, BlockingBehaviour block, List<AbstractBuildParameterFactory> configFactories,List<AbstractBuildParameters> configs) {
+        this(projects, block, configFactories, configs, true);
+    }
+    @DataBoundConstructor
+    public BlockableBuildTriggerConfig(String projects, BlockingBehaviour block, List<AbstractBuildParameterFactory> configFactories,List<AbstractBuildParameters> configs, boolean dependencyDeclared) {
         super(projects, ResultCondition.ALWAYS, false, configFactories, configs);
         this.block = block;
+        this.dependencyDeclared = dependencyDeclared;
     }
 
     public BlockingBehaviour getBlock() {
         return block;
+    }
+    
+    public boolean getDependencyDeclared() {
+        return dependencyDeclared;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -139,17 +139,20 @@ public class TriggerBuilder extends Builder implements DependecyDeclarer {
 
     @Override
     public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
-        for (BuildTriggerConfig config : configs)
-            for (AbstractProject project : config.getProjectList(owner.getParent(),null))
-                graph.addDependency(new ParameterizedDependency(owner, project, config) {
-                        @Override
-                        public boolean shouldTriggerBuild(AbstractBuild build,
-                                                          TaskListener listener,
-                                                          List<Action> actions) {
-                            // TriggerBuilders are inline already.
-                            return false;
-                        }
-                    });
+        for (BlockableBuildTriggerConfig config : configs)
+            if(config.getDependencyDeclared() == true) { 
+                // this is only done if required
+                for (AbstractProject project : config.getProjectList(owner.getParent(),null))
+                    graph.addDependency(new ParameterizedDependency(owner, project, config) {
+                            @Override
+                            public boolean shouldTriggerBuild(AbstractBuild build,
+                                                            TaskListener listener,
+                                                            List<Action> actions) {
+                                // TriggerBuilders are inline already.
+                                return false;
+                            }
+                        });
+            }
 
     }
     

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/config.jelly
@@ -31,7 +31,9 @@ THE SOFTWARE.
     <j:set var="instance" value="${instance[field]}"/>
     <st:include from="${descriptor}" page="${descriptor.configPage}" />
   </f:optionalBlock>
-
+  <f:entry title="${%Show Projects in dependancy lists}" field="dependencyDeclared" >
+        <f:checkbox default="true"/> 
+  </f:entry>
   <f:block>
     <f:hetero-list name="configs" hasHeader="true"
                    descriptors="${descriptor.getBuilderConfigDescriptors()}"

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/help-dependencyDeclared.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/help-dependencyDeclared.html
@@ -1,0 +1,29 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2012, Chris Johnson
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+  When checked, the projects are linked to this one and showup as downstream projects.<BR/>
+  If unchecked there is no connection shown between the projects.<BR/>
+  <B>Tip:</B> Use multiple triggers if you want only some projects to be shown.
+</div>


### PR DESCRIPTION
...d

Checkbox added to blockable builds trigger config so that projects added
in a build step are optionally not connected to the other projects.
default behaviour is to always link the projects.

https://issues.jenkins-ci.org/browse/JENKINS-15520
