### PR TITLE
Move to hamcrest 1.3 which is in repo.jenkins-ci.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-all</artifactId>
-          <version>1.2</version>
+          <version>1.3</version>
           <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
to ease building.

Version 1.2 is not avaliable in the repo.jenkins-ci.org, but 1.3 is so moving to that to allow builds to pass first time. rather than failing on it being missing.
