### PR TITLE
JENKINS-17009  Parameters with newlines should be stored as TextParameterValue 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.478</version>
     </parent>
 
     <artifactId>parameterized-trigger</artifactId>

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
@@ -2,13 +2,14 @@ package hudson.plugins.parameterizedtrigger;
 
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
-import hudson.model.Descriptor;
 import hudson.model.ParameterValue;
+import hudson.model.TaskListener;
+import hudson.model.AbstractBuild;
+import hudson.model.Descriptor;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
-import hudson.model.TaskListener;
+import hudson.model.TextParameterValue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,8 +39,14 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 		List<ParameterValue> values = new ArrayList<ParameterValue>();
 		for (Map.Entry<Object, Object> entry : p.entrySet()) {
-			values.add(new StringParameterValue(entry.getKey().toString(),
-					env.expand(entry.getValue().toString())));
+			// support multi-line parameters correctly
+			if(entry.getValue().toString().contains("\n")) {
+				values.add(new TextParameterValue(entry.getKey().toString(),
+						env.expand(entry.getValue().toString())));
+			} else {
+				values.add(new StringParameterValue(entry.getKey().toString(),
+						env.expand(entry.getValue().toString())));
+			}
 		}
 
 		return new ParametersAction(values);


### PR DESCRIPTION
Simple fix for problems with multiline parameters: if the value of the parameter contains a newline character then use a TextParameterValue, as this handles newlines better than StringParameterValue.

The result is that downstream plugins like the rebuild plugin can correctly handle these kind of parameter values then.
