### PR TITLE
[FIXED JENKINS-19973] - Added check for null build references

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction.java
@@ -221,9 +221,13 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
     for (String projectName : this.buildRefs.keySet()) {
       AbstractProject<?, ? extends AbstractBuild<?, ?>> project =
               Jenkins.getInstance().getItemByFullName(projectName, AbstractProject.class);
-      for (BuildReference br : this.buildRefs.get(projectName)) {
-        if (br.buildNumber == 0) {
-          projects.add(project);
+      
+      List<BuildReference> referencesToProject = this.buildRefs.get(projectName);
+      if (referencesToProject != null) {
+        for (BuildReference br : referencesToProject) {
+          if (br.buildNumber == 0) {
+            projects.add(project);
+          }
         }
       }
     }


### PR DESCRIPTION
Fix prevents NPE for renamed projects.
BTW, fix is a just a workaround...

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
