### PR TITLE
[FIXES JENKINS-20932] Avoid NPE by checking the getLastSuccessfulBuild()...

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -211,7 +211,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
             }
 
             // If oldBuild is null then we have already examined LastSuccessfulBuild as well.
-            if (currentBuild != null) {
+            if (currentBuild != null && context.getLastSuccessfulBuild() != null) {
                 resolveProject((AbstractBuild)context.getLastSuccessfulBuild(), subProjectData);
             }
         }


### PR DESCRIPTION
... for null before calling resolveProject()
