### PR TITLE
[JENKINS-22705] Fixed "Use files in matrix child builds" to work

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
@@ -49,20 +49,20 @@ public class FileBuildParameters extends AbstractBuildParameters {
 	
 	/*properties used for a matrix project*/
 	private final boolean useMatrixChild;
-	private final String combinatioFilter;
+	private final String combinationFilter;
 	private final boolean onlyExactRuns;
 
 	@DataBoundConstructor
-	public FileBuildParameters(String propertiesFile, String encoding, boolean failTriggerOnMissing, boolean useMatrixBuild, String combinationFilter, boolean onlyExactRuns) {
+	public FileBuildParameters(String propertiesFile, String encoding, boolean failTriggerOnMissing, boolean useMatrixChild, String combinationFilter, boolean onlyExactRuns) {
 		this.propertiesFile = propertiesFile;
 		this.encoding = Util.fixEmptyAndTrim(encoding);
 		this.failTriggerOnMissing = failTriggerOnMissing;
-		this.useMatrixChild = useMatrixBuild;
+		this.useMatrixChild = useMatrixChild;
 		if (this.useMatrixChild) {
-			this.combinatioFilter = combinationFilter;
+			this.combinationFilter = combinationFilter;
 			this.onlyExactRuns = onlyExactRuns;
 		} else {
-			this.combinatioFilter = null;
+			this.combinationFilter = null;
 			this.onlyExactRuns = false;
 		}
 	}
@@ -147,14 +147,14 @@ public class FileBuildParameters extends AbstractBuildParameters {
 						if (run == null) {
 							return false;
 						}
-						if (StringUtils.isBlank(getCombinatioFilter())) {
+						if (StringUtils.isBlank(getCombinationFilter())) {
 							// no combination filter stands for all children.
 							return true;
 						}
 						Combination c = run.getParent().getCombination();
 						AxisList axes = run.getParent().getParent().getAxes();
 						
-						return c.evalGroovyExpression(axes, getCombinatioFilter());
+						return c.evalGroovyExpression(axes, getCombinationFilter());
 					}
 				}
 			);
@@ -179,8 +179,8 @@ public class FileBuildParameters extends AbstractBuildParameters {
 		return useMatrixChild;
 	}
 	
-	public String getCombinatioFilter() {
-		return combinatioFilter;
+	public String getCombinationFilter() {
+		return combinationFilter;
 	}
 	
 	public boolean isOnlyExactRuns() {

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/config.jelly
@@ -9,7 +9,7 @@
   <!-- When rendered via Ajax, configFor is available only when Jenkins >= 1.495 -->
   <j:if test="${(configFor == null or configFor == 'publisher') and descriptor.isMatrixProject(it)}">
     <!-- Here is displayed only for matrix project-->
-    <f:optionalBlock field="useMatrixChild" title="${%Use files in matrix child builds}">
+    <f:optionalBlock field="useMatrixChild" title="${%Use files in matrix child builds}" inline="true">
       <f:entry field="combinationFilter" title="Combination Filter">
         <f:textbox />
       </f:entry>

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
@@ -744,7 +744,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         assertEquals("UTF-8", p.getEncoding());
         assertTrue(p.getFailTriggerOnMissing());
         assertTrue(p.isUseMatrixChild());
-        assertEquals("axis1=value1", p.getCombinatioFilter());
+        assertEquals("axis1=value1", p.getCombinationFilter());
         assertTrue(p.isOnlyExactRuns());
     }
 }


### PR DESCRIPTION
"Use files in matrix child builds" does not work at all for a very basic error (parameter name mismatching and typo).
I seem have verified the behavior only with test codes... I verified the behavior with my browser for this fix.
