### PR TITLE
[JENKINS-22856] Uses AbstractProject instead of Item in Descriptor.doCheckProjects

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -530,7 +530,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
          *
          * Copied from hudson.tasks.BuildTrigger.doCheck(Item project, String value)
          */
-        public FormValidation doCheckProjects(@AncestorInPath Item project, @QueryParameter String value ) {
+        public FormValidation doCheckProjects(@AncestorInPath AbstractProject<?,?> project, @QueryParameter String value ) {
             // Require CONFIGURE permission on this project
             if(!project.hasPermission(Item.CONFIGURE)){
             	return FormValidation.ok();


### PR DESCRIPTION
[JENKINS-22856](https://issues.jenkins-ci.org/browse/JENKINS-22856)

It can be get confused with JobPropertyImpl.getJobOverrides or /lib/form/withCustomDescriptorByName, that is, [Cloudbees Template plugin](http://www.cloudbees.com/jenkins-enterprise-by-cloudbees-features-templates-plugin.cb).

See following for more details:
https://groups.google.com/forum/#!topic/jenkinsci-dev/wOUBUlnE24Y
