### PR TITLE
Added new EXPLICIT ResultCondition

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -300,7 +300,6 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
         env.overrideAll(build.getBuildVariables());
 
         try {
-			if (condition.isMet(build.getResult())) {
                 List<Future<AbstractBuild>> futures = new ArrayList<Future<AbstractBuild>>();
 
                 for (List<AbstractBuildParameters> addConfigs : getDynamicBuildParameters(build, listener)) {
@@ -308,14 +307,15 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
                             ImmutableList.<AbstractBuildParameters>builder().addAll(configs).addAll(addConfigs).build(),
                             build, listener);
                     for (AbstractProject project : getProjectList(build.getRootBuild().getProject().getParent(),env)) {
+                      if (condition.isMet(build, listener, project)) {
                         List<Action> list = getBuildActions(actions, project);
 
                         futures.add(schedule(build, project, list));
+                      }
                     }
                 }
 
                 return futures;
-			}
 		} catch (DontTriggerException e) {
 			// don't trigger on this configuration
 		}
@@ -327,19 +327,19 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
         env.overrideAll(build.getBuildVariables());
 
         try {
-            if (getCondition().isMet(build.getResult())) {
                 ListMultimap<AbstractProject, Future<AbstractBuild>> futures = ArrayListMultimap.create();
 
                 for (List<AbstractBuildParameters> addConfigs : getDynamicBuildParameters(build, listener)) {
                     List<Action> actions = getBaseActions(ImmutableList.<AbstractBuildParameters>builder().addAll(configs).addAll(addConfigs).build(), build, listener);
                     for (AbstractProject project : getProjectList(build.getRootBuild().getProject().getParent(),env)) {
+                      if (condition.isMet(build, listener, project)) {
                         List<Action> list = getBuildActions(actions, project);
 
                         futures.put(project, schedule(build, project, list));
+                      }
                     }
                 }
                 return futures;
-            }
         } catch (DontTriggerException e) {
             // don't trigger on this configuration
         }

--- a/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedDependency.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedDependency.java
@@ -51,10 +51,10 @@ public class ParameterizedDependency extends Dependency {
 
 	@Override
 	public boolean shouldTriggerBuild(AbstractBuild build, TaskListener listener, List<Action> actions) {
-		if (!config.getCondition().isMet(build.getResult())){
-			return false;
-		}
 		try {
+			if (!config.getCondition().isMet(build, listener, getDownstreamProject())){
+				return false;
+			}
 			List<Action> actionList = config.getBaseActions(build, listener);
 			if (!actionList.isEmpty()) {
 				actions.addAll(config.getBuildActions(actionList, getDownstreamProject()));

--- a/src/main/java/hudson/plugins/parameterizedtrigger/ResultCondition.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ResultCondition.java
@@ -1,37 +1,68 @@
 package hudson.plugins.parameterizedtrigger;
 
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
 import hudson.model.Result;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 public enum ResultCondition {
 
 	SUCCESS("Stable") {
-		boolean isMet(Result result) {
-			return result == Result.SUCCESS;
+		boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
+			return build.getResult() == Result.SUCCESS;
 		}
 	},
     UNSTABLE("Unstable") {
-        boolean isMet(Result result) {
-            return result == Result.UNSTABLE;
+        boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
+            return build.getResult() == Result.UNSTABLE;
         }
     },
 	UNSTABLE_OR_BETTER("Stable or unstable but not failed") {
-		boolean isMet(Result result) {
-			return result.isBetterOrEqualTo(Result.UNSTABLE);
+		boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
+			return build.getResult().isBetterOrEqualTo(Result.UNSTABLE);
 		}
 	},
     UNSTABLE_OR_WORSE("Unstable or Failed but not stable") {
-		boolean isMet(Result result) {
-			return result.isWorseOrEqualTo(Result.UNSTABLE);
+		boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
+			return build.getResult().isWorseOrEqualTo(Result.UNSTABLE);
 		}
 	},
 	FAILED("Failed") {
-		boolean isMet(Result result) {
-			return result == Result.FAILURE;
+		boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
+			return build.getResult() == Result.FAILURE;
 		}
 	},
 	ALWAYS("Complete (always trigger)") {
-		boolean isMet(Result result) {
+		boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
 			return true;
+		}
+	},
+	EXPLICIT("Explitly requested (by environment variable)") {
+		boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException {
+			EnvVars env = build.getEnvironment(listener);
+			String name = downstream.getName();
+			listener.getLogger().println(name);
+			listener.getLogger().println(String.valueOf(env));
+
+			// See if there is a variable with the same name as the downstream job
+			if ("true".equals(env.get(name))) {
+				return true;
+			}
+
+			// See if the downstream job name is listed in the ALL_JOBS_NAME_VARIABLE variable
+			String jobs = env.get("TRIGGER_JOB_NAMES");
+			if (jobs != null) {
+				for (String job : jobs.trim().split("\\s*,\\s*")) {
+					if (name.equals(job)) {
+						return true;
+					}
+				}
+			}
+			return false;
 		}
 	};
 
@@ -40,11 +71,11 @@ public enum ResultCondition {
 	}
 
 	private final String displayName;
-	
+
 	public String getDisplayName() {
 		return displayName;
 	}
 
-	abstract boolean isMet(Result result);
-	
+	abstract boolean isMet(AbstractBuild<?, ?> build, TaskListener listener, AbstractProject<?, ?> downstream) throws IOException, InterruptedException;
+
 }

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/help-condition.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/help-condition.html
@@ -1,2 +1,12 @@
-<div>Determines for which results of the current build, the new build(s) will be triggered.</div>
+<div>
+<p>Determines for which results of the current build, the new build(s) will be triggered.</p>
+<p>
+The <b>Explicit</b> option is used for conditionally triggering downstream jobs.<br>
+There are two ways to select downstream jobs to trigger:
+<ul>
+  <li>through a build variable with the same name as the triggered downstream job (value must be <i>true</i>).</li>
+  <li>through the <i>TRIGGER_JOB_NAMES</i> environment variable (contains comma separated downstream job names).</li>
+</ul>
+</p>
+</div>
  


### PR DESCRIPTION
This new result condition can be used to explicitly control, what
downstream Jobs get trigger.

I'm kind of hoping this solves the post-build part of JENKINS-11280.
