### PR TITLE
Update dependency on subversion-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>1.25</version>
+            <version>1.40</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
1.25 throws errors in `SubversionRevisionBuildTriggerConfigTest`; some problem with SSL on `svn.jenkins-ci.org`. 1.40 is the earliest version I found that was OK.
