### PR TITLE
Provide an option to skip triggering when a build job is invoked manually

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
@@ -1,20 +1,12 @@
 package hudson.plugins.parameterizedtrigger;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
 import hudson.Extension;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.BuildListener;
-import hudson.model.Cause.UpstreamCause;
-import hudson.model.Hudson;
-import hudson.model.Node;
-import hudson.model.Run;
+import hudson.model.*;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -31,13 +23,13 @@ public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
     public boolean buildAllNodesWithLabel;
 
     public BlockableBuildTriggerConfig(String projects, BlockingBehaviour block, List<AbstractBuildParameters> configs) {
-        super(projects, ResultCondition.ALWAYS, false, configs);
+        super(projects, ResultCondition.ALWAYS, false, false, configs);
         this.block = block;
     }
 
     @DataBoundConstructor
     public BlockableBuildTriggerConfig(String projects, BlockingBehaviour block, List<AbstractBuildParameterFactory> configFactories,List<AbstractBuildParameters> configs) {
-        super(projects, ResultCondition.ALWAYS, false, configFactories, configs);
+        super(projects, ResultCondition.ALWAYS, false, false, configFactories, configs);
         this.block = block;
     }
 

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -56,31 +56,35 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
 	private String projects;
 	private final ResultCondition condition;
 	private boolean triggerWithNoParameters;
+  private boolean skipWhenInvokedManually;
 
     public BuildTriggerConfig(String projects, ResultCondition condition,
-            boolean triggerWithNoParameters, List<AbstractBuildParameterFactory> configFactories, List<AbstractBuildParameters> configs) {
+            boolean triggerWithNoParameters, boolean skipWhenInvokedManually, List<AbstractBuildParameterFactory> configFactories,
+            List<AbstractBuildParameters> configs) {
         this.projects = projects;
         this.condition = condition;
         this.triggerWithNoParameters = triggerWithNoParameters;
+        this.skipWhenInvokedManually = skipWhenInvokedManually;
         this.configFactories = configFactories;
         this.configs = Util.fixNull(configs);
     }
 
     @DataBoundConstructor
     public BuildTriggerConfig(String projects, ResultCondition condition,
-            boolean triggerWithNoParameters, List<AbstractBuildParameters> configs) {
-        this(projects, condition, triggerWithNoParameters, null, configs);
+            boolean triggerWithNoParameters, boolean skipWhenInvokedManually,
+            List<AbstractBuildParameters> configs) {
+        this(projects, condition, triggerWithNoParameters, skipWhenInvokedManually, null, configs);
     }
 
 	public BuildTriggerConfig(String projects, ResultCondition condition,
 			AbstractBuildParameters... configs) {
-		this(projects, condition, false, null, Arrays.asList(configs));
+		this(projects, condition, false, false, null, Arrays.asList(configs));
 	}
 
 	public BuildTriggerConfig(String projects, ResultCondition condition,
             List<AbstractBuildParameterFactory> configFactories,
 			AbstractBuildParameters... configs) {
-		this(projects, condition, false, configFactories, Arrays.asList(configs));
+		this(projects, condition, false, false, configFactories, Arrays.asList(configs));
 	}
 
 	public List<AbstractBuildParameters> getConfigs() {
@@ -106,6 +110,10 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
 	public boolean getTriggerWithNoParameters() {
         return triggerWithNoParameters;
     }
+
+  public boolean getSkipWhenInvokedManually() {
+      return skipWhenInvokedManually;
+  }
 
     /**
      * @deprecated

--- a/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildTriggerConfig.java
@@ -29,6 +29,6 @@ public class FileBuildTriggerConfig extends BuildTriggerConfig {
     	if (propertiesFile != null) {
     		configs.add(new FileBuildParameters(propertiesFile));
     	}
-		return new BuildTriggerConfig(projectsValue, condition, triggerWithNoParameters, configs);
+		return new BuildTriggerConfig(projectsValue, condition, triggerWithNoParameters, false, configs);
     }
 }

--- a/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedDependency.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedDependency.java
@@ -1,11 +1,7 @@
 package hudson.plugins.parameterizedtrigger;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.DependencyGraph;
+import hudson.model.*;
 import hudson.model.DependencyGraph.Dependency;
-import hudson.model.TaskListener;
 
 import java.util.List;
 
@@ -52,6 +48,10 @@ public class ParameterizedDependency extends Dependency {
 	@Override
 	public boolean shouldTriggerBuild(AbstractBuild build, TaskListener listener, List<Action> actions) {
 		if (!config.getCondition().isMet(build.getResult())){
+			return false;
+		}
+		Cause cause = build.getCause(Cause.UserIdCause.class);
+		if(config.getSkipWhenInvokedManually() && null != cause) {
 			return false;
 		}
 		try {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedPropertiesBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedPropertiesBuildTriggerConfig.java
@@ -29,6 +29,6 @@ public class PredefinedPropertiesBuildTriggerConfig extends BuildTriggerConfig {
     	if (properties != null) {
     		configs.add(new PredefinedBuildParameters(properties));
     	}
-		return new BuildTriggerConfig(projectsValue, condition, triggerWithNoParameters, configs);
+		return new BuildTriggerConfig(projectsValue, condition, triggerWithNoParameters, false, configs);
     }
 }

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
@@ -11,6 +11,9 @@
   <f:entry title="${%Trigger build without parameters}" field="triggerWithNoParameters" >
 	<f:checkbox checked="${instance.triggerWithNoParameters}"/>
   </f:entry>
+  <f:entry title="${%Skip trigger when invoked manually}" field="skipWhenInvokedManually" >
+  	<f:checkbox checked="${instance.skipWhenInvokedManually}"/>
+  </f:entry>
 
   <f:block>
     <f:hetero-list name="configs" hasHeader="true"

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/help-skipWhenInvokedManually.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/help-skipWhenInvokedManually.html
@@ -1,0 +1,2 @@
+<div>Skip the execution of a trigger when a job is started by a user. This allows the creation of the pipeline, while users are still able to manually call individual jobs from within that pipeline.</div>
+ 

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CurrentBuildParametersTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CurrentBuildParametersTest.java
@@ -27,19 +27,12 @@ import hudson.model.Cause.UserCause;
 import hudson.model.ParametersAction;
 import hudson.model.Project;
 import hudson.model.StringParameterValue;
-import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
-import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
-import hudson.plugins.parameterizedtrigger.BuildTrigger;
-import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
-import hudson.plugins.parameterizedtrigger.CurrentBuildParameters;
-import hudson.plugins.parameterizedtrigger.ResultCondition;
-import hudson.plugins.parameterizedtrigger.TriggerBuilder;
+import hudson.plugins.parameterizedtrigger.*;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 
 public class CurrentBuildParametersTest extends HudsonTestCase {
 
@@ -102,7 +95,7 @@ public class CurrentBuildParametersTest extends HudsonTestCase {
 		Project<?,?> projectA = createFreeStyleProject("projectA");
 		List<AbstractBuildParameters> buildParameters = new ArrayList<AbstractBuildParameters>();
 		buildParameters.add(new CurrentBuildParameters());
-		projectA.getPublishersList().add(new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, pWithoutParameters, buildParameters)));
+		projectA.getPublishersList().add(new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, pWithoutParameters, false, buildParameters)));
 		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
 
 		Project<?,?> projectB = createFreeStyleProject("projectB");

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
@@ -23,43 +23,24 @@
  */
 package hudson.plugins.parameterizedtrigger.test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.matrix.AxisList;
 import hudson.matrix.LabelAxis;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
-import hudson.model.Cause;
-import hudson.model.FreeStyleBuild;
-import hudson.model.ParameterValue;
-import hudson.model.FreeStyleProject;
-import hudson.model.ParametersAction;
-import hudson.model.Project;
-import hudson.model.StringParameterValue;
+import hudson.model.*;
 import hudson.model.labels.LabelExpression;
-import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
-import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
-import hudson.plugins.parameterizedtrigger.BuildTrigger;
-import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
-import hudson.plugins.parameterizedtrigger.FileBuildParameters;
-import hudson.plugins.parameterizedtrigger.ResultCondition;
-import hudson.plugins.parameterizedtrigger.TriggerBuilder;
+import hudson.plugins.parameterizedtrigger.*;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
-
 import org.apache.commons.io.FileUtils;
-import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
-import org.jvnet.hudson.test.Bug;
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.SingleFileSCM;
-import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
 
 public class FileBuildTriggerConfigTest extends HudsonTestCase {
 
@@ -306,7 +287,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
             
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, false, null, false)
                     ))
             ));
@@ -333,7 +314,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
             
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, true, null, false)
                     ))
             ));
@@ -461,7 +442,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
             
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, false, null, false)
                     ))
             ));
@@ -488,7 +469,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
             
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, true, null, false)
                     ))
             ));
@@ -604,7 +585,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         {
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, true, null, false)
                     ))
             ));
@@ -628,7 +609,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         {
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, true, "childname!='child2'", false)
                     ))
             ));
@@ -667,7 +648,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         {
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, true, null, false)
                     ))
             ));
@@ -691,7 +672,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         {
             upstream.getPublishersList().clear();
             upstream.getPublishersList().add(new BuildTrigger(
-                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                    new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                             new FileBuildParameters("properties.txt", null, false, true, null, true)
                     ))
             ));
@@ -719,7 +700,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         MatrixProject upstream = createMatrixProject();
         upstream.setAxes(new AxisList(new TextAxis("axis1", "value1", "value2")));
         upstream.getPublishersList().add(new BuildTrigger(
-                new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                         new FileBuildParameters("properties.txt", "UTF-8", true, true, "axis1=value1", true)
                 ))
         ));
@@ -772,7 +753,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         
         upstream.getBuildersList().add(new WriteFileBuilder("properties.txt", "relative_param2=value3"));
         upstream.getPublishersList().add(new BuildTrigger(
-                new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                         new FileBuildParameters(String.format("%s,../properties.txt,properties.txt", absoluteFile.getAbsolutePath()))
                 ))
         ));
@@ -818,7 +799,7 @@ public class FileBuildTriggerConfigTest extends HudsonTestCase {
         
         upstream.getBuildersList().add(new WorkspaceRemoveBuilder());
         upstream.getPublishersList().add(new BuildTrigger(
-                new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, Arrays.<AbstractBuildParameters>asList(
+                new BuildTriggerConfig(downstream.getFullName(), ResultCondition.SUCCESS, true, false, Arrays.<AbstractBuildParameters>asList(
                         new FileBuildParameters(absoluteFile.getAbsolutePath())
                 ))
         ));

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/RenameJobTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/RenameJobTest.java
@@ -24,29 +24,22 @@
 package hudson.plugins.parameterizedtrigger.test;
 
 import hudson.model.FreeStyleBuild;
-import hudson.model.TopLevelItemDescriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Project;
-import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
-import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
-import hudson.plugins.parameterizedtrigger.BuildTrigger;
-import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
-import hudson.plugins.parameterizedtrigger.CurrentBuildParameters;
-import hudson.plugins.parameterizedtrigger.ResultCondition;
-import hudson.plugins.parameterizedtrigger.TriggerBuilder;
+import hudson.model.TopLevelItemDescriptor;
+import hudson.plugins.parameterizedtrigger.*;
 import hudson.tasks.BuildStep;
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
+import org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder;
+import org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder;
+import org.jvnet.hudson.test.HudsonTestCase;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
-import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
-import org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder;
-import org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder;
-import org.jvnet.hudson.test.HudsonTestCase;
 
 public class RenameJobTest extends HudsonTestCase {
 
@@ -168,6 +161,7 @@ public class RenameJobTest extends HudsonTestCase {
                 p2.getName(),   // This should not be getFullName().
                 ResultCondition.ALWAYS,
                 true,
+                false,
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
         
@@ -240,6 +234,7 @@ public class RenameJobTest extends HudsonTestCase {
                     // This should not be getFullName().
                 ResultCondition.ALWAYS,
                 true,
+                false,
                 null,
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
@@ -313,6 +308,7 @@ public class RenameJobTest extends HudsonTestCase {
                     // This should not be getFullName().
                 ResultCondition.ALWAYS,
                 true,
+                false,
                 null,
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
@@ -376,6 +372,7 @@ public class RenameJobTest extends HudsonTestCase {
                 String.format("%s,%s", projectB.getName(), projectB2.getName()),
                 ResultCondition.ALWAYS,
                 true,
+                false,
                 null,
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/SkipWhenManuallyInvokedTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/SkipWhenManuallyInvokedTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.parameterizedtrigger.test;
+
+import hudson.model.Cause;
+import hudson.model.Project;
+import hudson.plugins.parameterizedtrigger.*;
+import hudson.triggers.SCMTrigger;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SkipWhenManuallyInvokedTest extends HudsonTestCase {
+
+	/**
+	 * Project A: Post-build build-trigger
+	 * 			  + currentBuildParameters
+	 *			  + no parameters defined
+	 *			  + Skip when manually invoked
+	 *	=> Project B should be not be triggered
+	 *
+	 * @throws Exception
+	 */
+	
+	public void testPostBuildTriggerSkipIfManuallyInvokedByUserCause() throws Exception {
+		Project<?,?> projectA = createFreeStyleProject("projectA");
+		List<AbstractBuildParameters> buildParameters = new ArrayList<AbstractBuildParameters>();
+		buildParameters.add(new CurrentBuildParameters());
+		projectA.getPublishersList().add(new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, true, true, buildParameters)));
+		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
+
+		Project<?,?> projectB = createFreeStyleProject("projectB");
+		projectB.getBuildersList().add(builder);
+		projectB.setQuietPeriod(1);
+		hudson.rebuildDependencyGraph();
+
+		projectA.scheduleBuild2(0, new Cause.UserIdCause()).get();
+		assertEquals(false, hudson.getQueue().contains(projectB));
+		List<String> log = projectA.getLastBuild().getLog(20);
+		for (String string : log) {
+			System.out.println(string);
+		}
+ 	}
+
+	/**
+	 * Project A: Post-build build-trigger
+	 * 			  + currentBuildParameters
+	 *			  + no parameters defined
+	 *			  + Skip when manually invoked = false
+	 *			  + cause = SCM Trigger
+	 *	=> Project B should be triggered
+	 *
+	 * @throws Exception
+	 */
+
+	public void testPostBuildTriggerExecuteIfSCMTriggerWhileSkipManuallyInvoked() throws Exception {
+		Project<?,?> projectA = createFreeStyleProject("projectA");
+		List<AbstractBuildParameters> buildParameters = new ArrayList<AbstractBuildParameters>();
+		buildParameters.add(new CurrentBuildParameters());
+		projectA.getPublishersList().add(new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, true, false, buildParameters)));
+		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
+
+		Project<?,?> projectB = createFreeStyleProject("projectB");
+		projectB.getBuildersList().add(builder);
+		projectB.setQuietPeriod(1);
+		hudson.rebuildDependencyGraph();
+
+		projectA.scheduleBuild2(0, new SCMTrigger.SCMTriggerCause("UnitTest")).get();
+		assertEquals(true, hudson.getQueue().contains(projectB));
+		List<String> log = projectA.getLastBuild().getLog(20);
+		for (String string : log) {
+			System.out.println(string);
+		}
+	}
+	
+}


### PR DESCRIPTION
Add an option which allows the user to choose between executing triggers like they normally do, or to skip them when a user was the cause of the build of this job. This allows users to decide whether or not they want to invoke a whole pipeline of jobs or if they just want to invoke a single job.