### PR TITLE
allow indicating project name in property files

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory.java
@@ -69,14 +69,21 @@ public class FileBuildParameterFactory extends AbstractBuildParameterFactory {
     }
 
     private final String filePattern;
+    private final String projectNameProperty;
     private final String encoding;
     private final NoFilesFoundEnum noFilesFoundAction;
 
     @DataBoundConstructor
-    public FileBuildParameterFactory(String filePattern, String encoding, NoFilesFoundEnum noFilesFoundAction) {
+    public FileBuildParameterFactory(String filePattern, String projectNameProperty,
+                                     String encoding, NoFilesFoundEnum noFilesFoundAction) {
         this.filePattern = filePattern;
+        this.projectNameProperty = Util.fixEmptyAndTrim(projectNameProperty);
         this.encoding = Util.fixEmptyAndTrim(encoding);
         this.noFilesFoundAction = noFilesFoundAction;
+    }
+
+    public FileBuildParameterFactory(String filePattern, String encoding, NoFilesFoundEnum noFilesFoundAction) {
+        this(filePattern, null, encoding, noFilesFoundAction);
     }
 
     public FileBuildParameterFactory(String filePattern, NoFilesFoundEnum noFilesFoundAction) {
@@ -89,6 +96,10 @@ public class FileBuildParameterFactory extends AbstractBuildParameterFactory {
 
     public String getFilePattern() {
         return filePattern;
+    }
+
+    public String getProjectNameProperty() {
+        return projectNameProperty;
     }
 
     public String getEncoding() {
@@ -113,7 +124,7 @@ public class FileBuildParameterFactory extends AbstractBuildParameterFactory {
                 for(FilePath f: files) {
                     String parametersStr = ParameterizedTriggerUtils.readFileToString(f, getEncoding());
                     Logger.getLogger(FileBuildParameterFactory.class.getName()).log(Level.INFO, null, "Triggering build with " + f.getName());
-                    result.add(new PredefinedBuildParameters(parametersStr));
+                    result.add(new PredefinedBuildParameters(parametersStr, projectNameProperty));
                 }
             }
         } catch (IOException ex) {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
@@ -21,10 +21,16 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 	private final String properties;
+	private final String projectNameProperty;
 
 	@DataBoundConstructor
-	public PredefinedBuildParameters(String properties) {
+	public PredefinedBuildParameters(String properties, String projectNameProperty) {
 		this.properties = properties;
+		this.projectNameProperty = projectNameProperty;
+	}
+
+	public PredefinedBuildParameters(String properties) {
+		this(properties, null);
 	}
 
 	public Action getAction(AbstractBuild<?,?> build, TaskListener listener)
@@ -36,6 +42,11 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 		List<ParameterValue> values = new ArrayList<ParameterValue>();
 		for (Map.Entry<Object, Object> entry : p.entrySet()) {
+			//exclude projectNameProperty key=value from returned Action
+			if (projectNameProperty != null &&
+					projectNameProperty.equals(entry.getKey().toString())) {
+				continue;
+			}
 			values.add(new StringParameterValue(entry.getKey().toString(),
 					env.expand(entry.getValue().toString())));
 		}
@@ -45,6 +56,19 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 	public String getProperties() {
 		return properties;
+	}
+
+	public String getProjectNameProperty() {
+		return projectNameProperty;
+	}
+
+	public String getProjectName() throws IOException, InterruptedException {
+		if (projectNameProperty != null) {
+			Properties p = ParameterizedTriggerUtils.loadProperties(getProperties());
+			return p.getProperty(projectNameProperty, null);
+		} else {
+			return null;
+		}
 	}
 
 	@Extension

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
@@ -20,6 +20,7 @@ if(builds.size() > 0) {
 								alt:"${item.iconColor.description}", height:"16", width:"16")
 						text(item.displayName)
 					}
+					text(item.description)
 				}
 			}
 		}

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory/config.jelly
@@ -8,6 +8,9 @@
     <f:enum>${it.getDescription()}</f:enum>
   </f:entry>
   <f:advanced>
+    <f:entry field="projectNameProperty" title="${%Project Name Property}">
+      <f:textbox />
+    </f:entry>
     <f:entry field="encoding" title="${%File Encoding}">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory/help-projectNameProperty.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory/help-projectNameProperty.html
@@ -1,0 +1,4 @@
+<div>
+  In case of triggering multiple builds of different projects, it is possible
+  to restrict which property files provide parameters for which project.
+</div>


### PR DESCRIPTION
When triggering multiple builds, it is now possible to wait for completion on multiple projects and indicate in property files what project they should trigger a build on.

For example, if we have 5 properties files:

``` properties
# foo.properties
JOB=foo
PARAM=12
```

``` properties
# bar-1.properties
JOB=bar
PARAM=1
```

``` properties
# bar-2.properties
JOB=bar
PARAM=2
```

``` properties
# baz-1.properties
JOB=baz
PARAM=1
```

``` properties
# baz-2.properties
JOB=baz
PARAM=2
```

And the following configuration on the parent job:
- Projects to build: `foo, bar, baz`
- For every property file, invoke one build:
  - File pattern: `*.properties`
  - Project Name Property: `JOB`

The result will be the following triggered builds:
1. `foo` with params from `foo.properties`
2. `bar` with params from `bar-1.properties`
3. `bar` with params from `bar-2.properties`
4. `baz` with params from `baz-1.properties`
5. `baz` with params from `baz-2.properties`

If the _Project Name Property_ field is left blank, the behaviour is the same as before: _For every property file, invoke one build_ **ON ALL** _Projects to build_.

Important: the value of _Project Name Property_ is **NOT** passed as a parameter to the downstream builds.

Signed-off-by: Robin Jarry robin.jarry@6wind.com
