### PR TITLE
Workflow build fails when futures is empty.

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -159,8 +159,8 @@ public class TriggerBuilder extends Builder {
 
     private String getProjectListAsString(List<Job> projectList){
         StringBuilder projectListString = new StringBuilder();
-        for (Iterator iterator = projectList.iterator(); iterator.hasNext();) {
-            AbstractProject project = (AbstractProject) iterator.next();
+        for (Iterator<Job> iterator = projectList.iterator(); iterator.hasNext();) {
+            Job project = iterator.next();
             projectListString.append(HyperlinkNote.encodeTo('/'+ project.getUrl(), project.getFullDisplayName()));
             if(iterator.hasNext()){
                 projectListString.append(", ");


### PR DESCRIPTION
The type of projectList was changed to `List<Job>` in #87, but items from the iterator were still being cast to AbstractProject for the log message.