### PR TITLE
Append build description to each build in the Subprojects view

### DIFF
--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
@@ -20,6 +20,9 @@ if(builds.size() > 0) {
 								alt:"${item.iconColor.description}", height:"16", width:"16")
 						text(item.displayName)
 					}
+					if (item.description != null && item.description != '') {
+						text(' ' + item.description)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Since the Parameter factory runs the same job with different parameters, it is hard to discern build which is which in the Subproject view when only a job name and build number are shown. It would be more informative if we include the build description too. You can use the Description Setter Plugin to auto set the build description to any unique parameters passed in from the Parameter Factory, allowing the end user to choose how this page should be displayed.

1 caviot: It seems the text() function turns strings from "<a href" to "&lt;a href". I would like it if any html links in the build description to work in the Subproject view.
![subproject_description](https://cloud.githubusercontent.com/assets/852882/10093273/98c8d31e-630d-11e5-829c-3a21e78054f0.jpg)
