### PR TITLE
convert parameters whose type is a subclass of StringParameterDefinition

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/ProjectSpecificParameterValuesActionTransform.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ProjectSpecificParameterValuesActionTransform.java
@@ -53,7 +53,7 @@ public class ProjectSpecificParameterValuesActionTransform implements ITransform
 
     private static boolean canConvert(ParameterDefinition def, ParameterValue v) {
         return def instanceof SimpleParameterDefinition &&
-            !(def instanceof StringParameterDefinition) &&
+            !(def.getClass().equals(StringParameterDefinition.class)) &&
             v.getClass().equals(StringParameterValue.class);
     }
 

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/ProjectSpecificParameterValuesActionTransformTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/ProjectSpecificParameterValuesActionTransformTest.java
@@ -7,6 +7,8 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 import hudson.model.Project;
+import hudson.model.TextParameterDefinition;
+import hudson.model.TextParameterValue;
 import hudson.plugins.parameterizedtrigger.ProjectSpecificParameterValuesActionTransform;
 
 import java.io.IOException;
@@ -32,5 +34,25 @@ public class ProjectSpecificParameterValuesActionTransformTest extends HudsonTes
         assertEquals(1, result.getParameters().size(), 1);
         assertTrue(result.getParameter("key1") instanceof BooleanParameterValue);
         assertTrue(((BooleanParameterValue)result.getParameter("key1")).value);
+    }
+
+    public void testStringParamSubclass() throws IOException {
+        Project project = createFreeStyleProject("project");
+
+        project.addProperty(new ParametersDefinitionProperty(
+                    new TextParameterDefinition("key1", "herpderp", "derp")
+                    ));
+
+        ParametersAction action = new ParametersAction(
+                new StringParameterValue("key1", "herpaderp")
+                );
+
+        ProjectSpecificParameterValuesActionTransform transform = new ProjectSpecificParameterValuesActionTransform();
+
+        ParametersAction result = transform.transformParametersAction(action, project);
+
+        assertEquals(1, result.getParameters().size(), 1);
+        assertTrue(result.getParameter("key1") instanceof TextParameterValue);
+        assertEquals(((TextParameterValue)result.getParameter("key1")).value, "herpaderp");
     }
 }


### PR DESCRIPTION
ParameterDefinition types which extend StringParameterDefinition still need
to be converted, when possible, in order to ensure correct handling of any
additional logic implemented by the sub-type.

This fix is motivated by a parameter type, in one of my own plugins, which inherits from StringParameterDefinition in order to also reproduce its environment value insertion for free.  However, builds which were triggered from this plugin were not correctly calling into the types additional build time logic.
