### PR TITLE
JENKINS-17009: Parameters with newlines should be stored as TextParam…

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
@@ -19,6 +19,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
+import hudson.model.TextParameterValue;
 import hudson.util.FormValidation;
 
 import org.apache.commons.io.IOUtils;
@@ -143,8 +144,13 @@ public class FileBuildParameters extends AbstractBuildParameters {
 			Properties p = ParameterizedTriggerUtils.loadProperties(s);
 
 			for (Map.Entry<Object, Object> entry : p.entrySet()) {
-				values.add(new StringParameterValue(entry.getKey().toString(),
-						entry.getValue().toString()));
+				// support multi-line parameters correctly
+				s = entry.getValue().toString();
+				if(s.contains("\n")) {
+					values.add(new TextParameterValue(entry.getKey().toString(), s));
+				} else {
+					values.add(new StringParameterValue(entry.getKey().toString(), s));
+				}
 			}
 		}
 		return values;

--- a/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/FileBuildParameters.java
@@ -49,6 +49,7 @@ public class FileBuildParameters extends AbstractBuildParameters {
 	private final String propertiesFile;
 	private final String encoding;
 	private final boolean failTriggerOnMissing;
+	private final boolean textParamValueOnNewLine;
 	
 	/*properties used for a matrix project*/
 	private final boolean useMatrixChild;
@@ -56,7 +57,7 @@ public class FileBuildParameters extends AbstractBuildParameters {
 	private final boolean onlyExactRuns;
 
 	@DataBoundConstructor
-	public FileBuildParameters(String propertiesFile, String encoding, boolean failTriggerOnMissing, boolean useMatrixChild, String combinationFilter, boolean onlyExactRuns) {
+	public FileBuildParameters(String propertiesFile, String encoding, boolean failTriggerOnMissing, boolean useMatrixChild, String combinationFilter, boolean onlyExactRuns, boolean textParamValueOnNewLine) {
 		this.propertiesFile = propertiesFile;
 		this.encoding = Util.fixEmptyAndTrim(encoding);
 		this.failTriggerOnMissing = failTriggerOnMissing;
@@ -68,6 +69,11 @@ public class FileBuildParameters extends AbstractBuildParameters {
 			this.combinationFilter = null;
 			this.onlyExactRuns = false;
 		}
+		this.textParamValueOnNewLine = textParamValueOnNewLine;
+	}
+
+	public FileBuildParameters(String propertiesFile, String encoding, boolean failTriggerOnMissing, boolean useMatrixChild, String combinationFilter, boolean onlyExactRuns) {
+		this(propertiesFile, encoding, failTriggerOnMissing, useMatrixChild, combinationFilter, onlyExactRuns, false);
 	}
 
 	public FileBuildParameters(String propertiesFile, String encoding, boolean failTriggerOnMissing) {
@@ -146,7 +152,7 @@ public class FileBuildParameters extends AbstractBuildParameters {
 			for (Map.Entry<Object, Object> entry : p.entrySet()) {
 				// support multi-line parameters correctly
 				s = entry.getValue().toString();
-				if(s.contains("\n")) {
+				if(textParamValueOnNewLine && s.contains("\n")) {
 					values.add(new TextParameterValue(entry.getKey().toString(), s));
 				} else {
 					values.add(new StringParameterValue(entry.getKey().toString(), s));
@@ -191,6 +197,10 @@ public class FileBuildParameters extends AbstractBuildParameters {
 
 	public boolean getFailTriggerOnMissing() {
 		return failTriggerOnMissing;
+	}
+
+	public boolean getTextParamValueOnNewLine() {
+		return textParamValueOnNewLine;
 	}
 
 	public boolean isUseMatrixChild() {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
@@ -22,10 +22,17 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 	private final String properties;
+	private final boolean textParamValueOnNewLine;
+
 
 	@DataBoundConstructor
-	public PredefinedBuildParameters(String properties) {
+	public PredefinedBuildParameters(String properties, boolean textParamValueOnNewLine) {
 		this.properties = properties;
+		this.textParamValueOnNewLine = textParamValueOnNewLine;
+	}
+
+	public PredefinedBuildParameters(String properties) {
+		this(properties, false);
 	}
 
 	public Action getAction(AbstractBuild<?,?> build, TaskListener listener)
@@ -39,7 +46,7 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 		for (Map.Entry<Object, Object> entry : p.entrySet()) {
 			// support multi-line parameters correctly
 			String s = entry.getValue().toString();
-			if(s.contains("\n")) {
+			if(textParamValueOnNewLine && s.contains("\n")) {
 				values.add(new TextParameterValue(entry.getKey().toString(), env.expand(s)));
 			} else {
 				values.add(new StringParameterValue(entry.getKey().toString(), env.expand(s)));
@@ -51,6 +58,10 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 	public String getProperties() {
 		return properties;
+	}
+
+	public boolean getTextParamValueOnNewLine() {
+		return textParamValueOnNewLine;
 	}
 
 	@Extension

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
@@ -9,6 +9,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
+import hudson.model.TextParameterValue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,8 +37,13 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 		List<ParameterValue> values = new ArrayList<ParameterValue>();
 		for (Map.Entry<Object, Object> entry : p.entrySet()) {
-			values.add(new StringParameterValue(entry.getKey().toString(),
-					env.expand(entry.getValue().toString())));
+			// support multi-line parameters correctly
+			String s = entry.getValue().toString();
+			if(s.contains("\n")) {
+				values.add(new TextParameterValue(entry.getKey().toString(), env.expand(s)));
+			} else {
+				values.add(new StringParameterValue(entry.getKey().toString(), env.expand(s)));
+			}
 		}
 
 		return new ParametersAction(values);

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/config.jelly
@@ -22,6 +22,9 @@
     <f:entry field="encoding" title="${%File Encoding}">
       <f:textbox />
     </f:entry>
+    <f:entry field="textParamValueOnNewLine" title="${%Use TextParameterValue if property contains newline}">
+      <f:checkbox default="false" />
+    </f:entry>
   </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/help-textParamValueOnNewLine.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/help-textParamValueOnNewLine.html
@@ -1,0 +1,9 @@
+<div>
+  When enabled properties containing newline character(s) are propagated as
+  <a href="http://javadoc.jenkins-ci.org/hudson/model/TextParameterValue.html">TextParameterValue</a> which is a specialized
+  <a href="http://javadoc.jenkins-ci.org/hudson/model/StringParameterValue.html">StringParameterValue</a> commonly used for
+  handling multi-line strings in Jenkins. When disabled (default) all properties are propagated as StringParameterValue.
+  <p/>
+  TextParameterValue and StringParameterValue are typically rendered differently by Jenkins and plugins such as the
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Rebuild+Plugin">Rebuild plugin</a>.
+</div>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters/config.jelly
@@ -3,5 +3,10 @@
   <f:entry field="properties" title="Parameters">
     <f:textarea />
   </f:entry>
+  <f:advanced>
+    <f:entry field="textParamValueOnNewLine" title="${%Use TextParameterValue if property contains newline}">
+      <f:checkbox default="false" />
+    </f:entry>
+  </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters/help-textParamValueOnNewLine.html
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters/help-textParamValueOnNewLine.html
@@ -1,0 +1,9 @@
+<div>
+  When enabled properties containing newline character(s) are propagated as
+  <a href="http://javadoc.jenkins-ci.org/hudson/model/TextParameterValue.html">TextParameterValue</a> which is a specialized
+  <a href="http://javadoc.jenkins-ci.org/hudson/model/StringParameterValue.html">StringParameterValue</a> commonly used for
+  handling multi-line strings in Jenkins. When disabled (default) all properties are propagated as StringParameterValue.
+  <p/>
+  TextParameterValue and StringParameterValue are typically rendered differently by Jenkins and plugins such as the
+  <a href="https://wiki.jenkins-ci.org/display/JENKINS/Rebuild+Plugin">Rebuild plugin</a>.
+</div>


### PR DESCRIPTION
Rebased centic9's patch from [1]: https://github.com/jenkinsci/parameterized-trigger-plugin/pull/36.

In the discussion in [1], it is suggested that this is NOT a bug in the parameterized-trigger-plugin.

I would like to argue that this is in fact a bug in parameterized-trigger-plugin since it makes assumptions about the specific ParameterValue type. It always assumes that if its a String than it must be a StringParameterValue, which is clearly wrong. TextParameterValue was invented for multi-line strings, and it cannot be disregarded, since Jenkins and other plugins (rebuild) use this type information to render the correct UI.

Without this patch the "Predefined parameters" and "Parameters from property file" are useless for multi-line strings. 

This is a trivial change, please be pragmatic about it.
