### PR TITLE
Upgrade to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>2.3</version>
     </parent>
     
     <licenses>
@@ -55,6 +55,10 @@
                     <groupId>org.sonatype.sisu</groupId>
                     <artifactId>sisu-guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.sonatype.sisu</groupId>
+                    <artifactId>sisu-guice</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -99,13 +103,7 @@
     </dependencies>
 
     <build>
-      <plugins>
-       <plugin>
-            <groupId>org.jenkins-ci.tools</groupId>
-            <artifactId>maven-hpi-plugin</artifactId>
-            <version>1.97</version>
-            <extensions>true</extensions>
-        </plugin>      
+      <plugins>   
         <plugin>
           <!-- make sure our code doesn't have 1.6 dependencies except where we know it -->
           <groupId>org.jvnet</groupId>
@@ -182,6 +180,9 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <workflow.version>1.4</workflow.version>
+      <jenkins.version>1.580.1</jenkins.version>
+      <jenkins-test-harness.version>1.580.1</jenkins-test-harness.version>
+      <hpi-plugin.version>1.97</hpi-plugin.version>
     </properties>
 </project>  
 


### PR DESCRIPTION
Upgrade to new parent pom.  The test-harness-version is kept at 1.580 due to it's older version of htmlunit.  It might be worth looking into upgrading the tests in the future.