### PR TITLE
[JENKINS-32527] Handle null @AncestorInPath when selecting Downstream…

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -661,6 +661,8 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
          * Copied from hudson.tasks.BuildTrigger.doCheck(Item project, String value)
          */
         public FormValidation doCheckProjects(@AncestorInPath Job<?,?> project, @QueryParameter String value ) {
+            // JENKINS-32527: Check that it behaves gracefully for an unknown context
+            if (project == null) return FormValidation.ok("Context Unknown: the value specified cannot be validated");
             // Require CONFIGURE permission on this project
             if(!project.hasPermission(Item.CONFIGURE)){
             	return FormValidation.ok();


### PR DESCRIPTION
… Jobs

@reviewbybees Same as JENKINS-32525 and JENKINS-32526

I added some field validation tests for the `doCheckProjects` methods
