### PR TITLE
Add an ability to pass build parameters to post build trigger

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -92,7 +92,7 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer {
 			}
 		}
 
-		if (canDeclare(build.getProject())) {
+		if (canDeclare(build.getProject()) && !hasEnvVariables) {
 			// job will get triggered by dependency graph, so we have to capture buildEnvironment NOW before
 			// hudson.model.AbstractBuild.AbstractBuildExecution#cleanUp is called and reset
 			EnvVars env = build.getEnvironment(listener);

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -1,26 +1,35 @@
 package hudson.plugins.parameterizedtrigger;
 
+import com.google.common.collect.ImmutableList;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.console.ModelHyperlinkNote;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.DependecyDeclarer;
 import hudson.model.DependencyGraph;
+import hudson.model.Job;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
-import hudson.model.Job;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 public class BuildTrigger extends Notifier implements DependecyDeclarer {
 
@@ -49,43 +58,97 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer {
 		return BuildStepMonitor.NONE;
 	}
 
+	@Override
+	public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
+		return ImmutableList.of(new DynamicProjectAction(configs));
+	}
+
 	@Override @SuppressWarnings("deprecation")
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+		Map<String, AbstractBuild> downstreamMap = new HashMap<String, AbstractBuild>();
+		Map<String, Integer> buildMap = new HashMap<String, Integer>();
+		boolean hasEnvVariables = false;
 
-        HashSet<BuildTriggerConfig> alreadyFired = new HashSet<BuildTriggerConfig>();
+		HashSet<BuildTriggerConfig> alreadyFired = new HashSet<BuildTriggerConfig>();
 
-        // If this project has non-abstract projects, we need to fire them
-        for (BuildTriggerConfig config : configs) {
-            boolean hasNonAbstractProject = false;
+		// If this project has non-abstract projects, we need to fire them
+		for (BuildTriggerConfig config : configs) {
+			boolean hasNonAbstractProject = false;
+			hasEnvVariables = hasEnvVariables || hasEnvVariables(config, build.getEnvironment(listener));
 
-            List<Job> jobs = config.getJobs(build.getRootBuild().getProject().getParent(), build.getEnvironment(listener));
-            for (Job j : jobs) {
-                if (!(j instanceof AbstractProject)) {
-                    hasNonAbstractProject = true;
-                    break;
-                }
-            }
-            // Fire this config's projects if not already fired
-            if (hasNonAbstractProject) {
-                config.perform(build, launcher, listener);
-                alreadyFired.add(config);
-            }
-        }
+			List<Job> jobs = config.getJobs(build.getRootBuild().getProject().getParent(), build.getEnvironment(listener));
 
-        if (canDeclare(build.getProject())) {
-            // job will get triggered by dependency graph, so we have to capture buildEnvironment NOW before
-            // hudson.model.AbstractBuild.AbstractBuildExecution#cleanUp is called and reset
-            EnvVars env = build.getEnvironment(listener);
-            build.addAction(new CapturedEnvironmentAction(env));
-        } else {  // Not using dependency graph
-            for (BuildTriggerConfig config : configs) {
-                if (!alreadyFired.contains(config)) {
-                     config.perform(build, launcher, listener);
-                }
-            }
-        }
+
+			for (Job j : jobs) {
+				if (!(j instanceof AbstractProject)) {
+					hasNonAbstractProject = true;
+					break;
+				}
+			}
+			// Fire this config's projects if not already fired
+			if (hasNonAbstractProject) {
+				config.perform(build, launcher, listener);
+				alreadyFired.add(config);
+			}
+		}
+
+		if (canDeclare(build.getProject())) {
+			// job will get triggered by dependency graph, so we have to capture buildEnvironment NOW before
+			// hudson.model.AbstractBuild.AbstractBuildExecution#cleanUp is called and reset
+			EnvVars env = build.getEnvironment(listener);
+			build.addAction(new CapturedEnvironmentAction(env));
+		}
+		else {  // Not using dependency graph
+			for (BuildTriggerConfig config : configs) {
+				if (!alreadyFired.contains(config)) {
+					//config.perform(build, launcher, listener);
+					List<Future<AbstractBuild>> futures = config.perform(build, launcher, listener);
+					for (Future future : futures) {
+						AbstractBuild abstractBuild = null;
+						try {
+							abstractBuild = (AbstractBuild) future.get();
+							if (null != abstractBuild) {
+								downstreamMap.put(abstractBuild.getProject().getFullName(), abstractBuild);
+							}
+						} catch (ExecutionException e) {
+							listener.getLogger().println("Failed to execute downstream build");
+						}
+					}
+
+					String[] projects = config.getProjects(build.getEnvironment(listener)).split(",");
+					String[] vars = config.getProjects().split(",");
+					for (int i = 0; i < projects.length; i++) {
+						if (vars[i].trim().contains("$")) {
+							AbstractBuild abstractBuild = downstreamMap.get(projects[i]);
+							if (null != abstractBuild) {
+								listener.getLogger().println(makeLogEntry(projects[i].trim()));
+								buildMap.put(abstractBuild.getProject().getFullName(), abstractBuild.getNumber());
+							}
+						}
+					}
+
+				}
+				DynamicBuildAction action = new DynamicBuildAction(buildMap);
+				build.addAction(action);
+			}
+		}
 
 		return true;
+	}
+
+	private String makeLogEntry(String name) {
+		String url = name;
+		url = Jenkins.getInstance().getRootUrl() + "job/" + url.replaceAll("/", "/job/");
+		name = name.replaceAll("/", " » ");
+		String link = ModelHyperlinkNote.encodeTo(url, name);
+		StringBuilder sb = new StringBuilder();
+		sb.append("Triggering a new build of ");
+		sb.append(link);
+		return sb.toString();
+	}
+
+	private boolean hasEnvVariables(BuildTriggerConfig config, EnvVars env) {
+		return !config.getProjects().equalsIgnoreCase(config.getProjects(env));
 	}
 
 	@Override

--- a/src/main/java/hudson/plugins/parameterizedtrigger/DynamicBuildAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/DynamicBuildAction.java
@@ -11,6 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Shows a list of a dynamic downstream builds
+ */
 public class DynamicBuildAction implements RunAction2 {
 
     private Map<String, Integer> buildsMap;

--- a/src/main/java/hudson/plugins/parameterizedtrigger/DynamicBuildAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/DynamicBuildAction.java
@@ -1,0 +1,64 @@
+package hudson.plugins.parameterizedtrigger;
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.model.Jenkins;
+import jenkins.model.RunAction2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DynamicBuildAction implements RunAction2 {
+
+    private Map<String, Integer> buildsMap;
+
+    public DynamicBuildAction(Map<String, Integer> buildsMap) {
+        this.buildsMap = buildsMap;
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> run) {
+
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> run) {
+
+    }
+
+    public List<AbstractBuild<?, ?>> getBuilds() {
+        List<AbstractBuild<?, ?>> builds = new ArrayList<AbstractBuild<?, ?>>();
+        Jenkins j = Jenkins.getInstance();
+        for (Map.Entry<String, Integer> entry : buildsMap.entrySet()) {
+            Job<?, ?> job = j.getItemByFullName(entry.getKey(), Job.class);
+            if (null != job && job instanceof AbstractProject) {
+                AbstractProject project = (AbstractProject) job;
+                AbstractBuild build = project.getBuildByNumber(entry.getValue());
+                if (null != build) {
+                    builds.add(build);
+                }
+            }
+        }
+
+        return builds;
+    }
+
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/main/java/hudson/plugins/parameterizedtrigger/DynamicProjectAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/DynamicProjectAction.java
@@ -5,6 +5,9 @@ import hudson.model.Action;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Shows a list of a downstream jobs that specified with parameters.
+ */
 public class DynamicProjectAction implements Action {
 
     private List<BuildTriggerConfig> configs;

--- a/src/main/java/hudson/plugins/parameterizedtrigger/DynamicProjectAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/DynamicProjectAction.java
@@ -1,0 +1,42 @@
+package hudson.plugins.parameterizedtrigger;
+
+import hudson.model.Action;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DynamicProjectAction implements Action {
+
+    private List<BuildTriggerConfig> configs;
+
+    public DynamicProjectAction(List<BuildTriggerConfig> configs) {
+        this.configs = configs;
+    }
+
+    public List<String> getProjects() {
+        List<String> projects = new ArrayList<String>();
+        for (BuildTriggerConfig config : configs) {
+            for (String project : config.getProjects().split(",")) {
+                if (project.trim().contains("$")) {
+                    projects.add(project.trim());
+                }
+            }
+        }
+        return projects;
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
@@ -8,7 +8,6 @@ def l=namespace(lib.LayoutTagLib)
 def acts = my.builds
 if (!acts.empty) {
     h2(_("Dynamic downstream projects"))
-    h3("build count " + acts.size())
     my.builds.each { build ->
         ul(style: "list-style-type: none;") {
             li {
@@ -16,10 +15,6 @@ if (!acts.empty) {
                     text("Build is null")
                 } else {
                     def prj = build.getProject()
-                    text("build")
-                    text(build.getDisplayName())
-                    text(" number ")
-                    text(build.getNumber())
                     if (null == prj) {
                         text("Project is null")
                     } else {

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
@@ -1,10 +1,5 @@
 package hudson.plugins.parameterizedtrigger.DynamicBuildAction
 
-def f=namespace(lib.FormTagLib)
-def j=namespace(lib.JenkinsTagLib)
-def l=namespace(lib.LayoutTagLib)
-
-
 def acts = my.builds
 if (!acts.empty) {
     h2(_("Dynamic downstream projects"))

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
@@ -1,0 +1,40 @@
+package hudson.plugins.parameterizedtrigger.DynamicBuildAction
+
+def f=namespace(lib.FormTagLib)
+def j=namespace(lib.JenkinsTagLib)
+def l=namespace(lib.LayoutTagLib)
+
+
+def acts = my.builds
+if (!acts.empty) {
+    h2(_("Dynamic downstream projects"))
+    h3("build count " + acts.size())
+    my.builds.each { build ->
+        ul(style: "list-style-type: none;") {
+            li {
+                if (null == build) {
+                    text("Build is null")
+                } else {
+                    def prj = build.getProject()
+                    text("build")
+                    text(build.getDisplayName())
+                    text(" number ")
+                    text(build.getNumber())
+                    if (null == prj) {
+                        text("Project is null")
+                    } else {
+                        a(href: "${rootURL}/${build.getProject().getUrl()}", class: "model-link") {
+                            img(src: "${imagesURL}/16x16/${build.getResult().color.getImage()}",
+                                    alt: "${build.getResult().toString()}", height: "16", width: "16")
+                            text(build.getProject().getFullDisplayName())
+                        }
+                        text("   ")
+                        a(href: "${rootURL}/${build.url}", class: "model-link") {
+                            text("build " + build.getDisplayName())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicProjectAction/jobMain.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicProjectAction/jobMain.groovy
@@ -1,0 +1,18 @@
+package hudson.plugins.parameterizedtrigger.DynamicProjectAction
+
+def f=namespace(lib.FormTagLib)
+def j=namespace(lib.JenkinsTagLib)
+def l=namespace(lib.LayoutTagLib)
+
+
+def acts = my.projects
+if (!acts.empty) {
+    h2(_("Dynamic downstream projects"))
+    my.projects.each { project ->
+        ul(style: "list-style-type: none;") {
+            li {
+                text(project)
+            }
+        }
+    }
+}

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicProjectAction/jobMain.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicProjectAction/jobMain.groovy
@@ -1,10 +1,5 @@
 package hudson.plugins.parameterizedtrigger.DynamicProjectAction
 
-def f=namespace(lib.FormTagLib)
-def j=namespace(lib.JenkinsTagLib)
-def l=namespace(lib.LayoutTagLib)
-
-
 def acts = my.projects
 if (!acts.empty) {
     h2(_("Dynamic downstream projects"))


### PR DESCRIPTION
Ability to pass build parameters in the post-build action 'Trigger parameterized build on other projects'.
Like ${bugID}/assembly, which ${bugID} is a string build parameter.
Also, I've added actions to job and build that shows a list of downstream projects that passed with parameters.

<img width="434" alt="screen shot 2016-04-21 at 7 55 36 pm" src="https://cloud.githubusercontent.com/assets/1222848/14711867/3986a2bc-0805-11e6-8092-52a2e9693753.png">
<img width="601" alt="screen shot 2016-04-21 at 7 55 27 pm" src="https://cloud.githubusercontent.com/assets/1222848/14711885/43caa14c-0805-11e6-8f8f-4334ce352245.png">
