### PR TITLE
[JENKINS-34474] New parent pom (2.7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>2.3</version>
     </parent>
     
     <licenses>
@@ -55,6 +55,10 @@
                     <groupId>org.sonatype.sisu</groupId>
                     <artifactId>sisu-guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.sonatype.sisu</groupId>
+                    <artifactId>sisu-guice</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -99,13 +103,7 @@
     </dependencies>
 
     <build>
-      <plugins>
-       <plugin>
-            <groupId>org.jenkins-ci.tools</groupId>
-            <artifactId>maven-hpi-plugin</artifactId>
-            <version>1.97</version>
-            <extensions>true</extensions>
-        </plugin>      
+      <plugins>   
         <plugin>
           <!-- make sure our code doesn't have 1.6 dependencies except where we know it -->
           <groupId>org.jvnet</groupId>
@@ -182,6 +180,9 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <workflow.version>1.4</workflow.version>
+      <jenkins.version>1.580.1</jenkins.version>
+      <jenkins-test-harness.version>1.580.1</jenkins-test-harness.version>
+      <hpi-plugin.version>1.97</hpi-plugin.version>
     </properties>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>conditional-buildstep</artifactId>
+          <version>1.3.1</version>
+        </dependency>      
+         
         <!-- Workflow plugin imports are used to test compatibility -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -105,12 +110,6 @@
              </exclusion>
           </exclusions>
         </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>conditional-buildstep</artifactId>
-          <version>1.3.1</version>
-          <optional>true</optional>
-         </dependency>      
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.7</version>
     </parent>
     
     <licenses>
@@ -36,19 +36,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>1.38</version>
-            <optional>true</optional>
+            <version>2.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.4</version>
-            <optional>true</optional>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>promoted-builds</artifactId>
-            <version>2.10</version>
+            <version>2.25</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -59,13 +57,15 @@
                     <groupId>org.sonatype.sisu</groupId>
                     <artifactId>sisu-guice</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-          <version>1.3</version>
-          <scope>test</scope>
         </dependency>
 
         <!-- Workflow plugin imports are used to test compatibility -->
@@ -87,80 +87,37 @@
             <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <version>1.8.5</version>
-          <scope>test</scope>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>matrix-auth</artifactId>
+	      <version>1.3.2</version>
+	      <scope>test</scope>
         </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>conditional-buildstep</artifactId>
-        <version>1.3.1</version>
-        <optional>true</optional>
-      </dependency>      
+        <dependency>
+           <groupId>org.mockito</groupId>
+           <artifactId>mockito-core</artifactId>
+           <version>1.8.5</version>
+          <scope>test</scope>
+          <exclusions>
+            <exclusion>
+	            <groupId>org.hamcrest</groupId>
+	            <artifactId>hamcrest-core</artifactId>
+             </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>conditional-buildstep</artifactId>
+          <version>1.3.1</version>
+          <optional>true</optional>
+         </dependency>      
     </dependencies>
-
-    <build>
-      <plugins>   
-        <plugin>
-          <!-- make sure our code doesn't have 1.6 dependencies except where we know it -->
-          <groupId>org.jvnet</groupId>
-          <artifactId>animal-sniffer</artifactId>
-          <version>1.2</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <configuration>
-                <signature>
-                  <groupId>org.jvnet.animal-sniffer</groupId>
-                  <artifactId>java1.6</artifactId>
-                  <version>1.0</version>
-                </signature>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-        <pluginManagement>
-            <plugins>
-                <!-- Ignore animal-sniffer plugin when run with m2e on Eclipse. -->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.jvnet</groupId>
-                                        <artifactId>animal-sniffer</artifactId>
-                                        <versionRange>[1.2,)</versionRange>
-                                        <goals>
-                                            <goal>check</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>      
-    </build>
 
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/parameterized-trigger-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/parameterized-trigger-plugin.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>
@@ -177,12 +134,10 @@
     </pluginRepositories>
     
     <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <workflow.version>1.4</workflow.version>
-      <jenkins.version>1.580.1</jenkins.version>
-      <jenkins-test-harness.version>1.580.1</jenkins-test-harness.version>
-      <hpi-plugin.version>1.97</hpi-plugin.version>
+      <jenkins.version>1.596.1</jenkins.version>
+      <java.level>6</java.level>
+      <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
             <version>2.5.7</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -154,12 +154,12 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
     /**
      * Provides a SubProjectData object containing four set, each containing projects to be displayed on the project
      * view under 'Subprojects' section.<br>
-     * <li>
-     * The first set contains fixed (statically) configured project to be trigger.
-     * The second set contains dynamically configured project, resolved by back tracking builds environment variables.
-     * The third set contains other recently triggered project found during back tracking builds
-     * The fourth set contains dynamically configured project that couldn't be resolved or project that doesn't exists.
-     * </li>
+     * <ul>
+     * <li>The first set contains fixed (statically) configured project to be trigger.</li>
+     * <li>The second set contains dynamically configured project, resolved by back tracking builds environment variables.</li>
+     * <li>The third set contains other recently triggered project found during back tracking builds</li>
+     * <li>The fourth set contains dynamically configured project that couldn't be resolved or project that doesn't exists.</li>
+     * </ul>
      *
      * @param context   The container with which to resolve relative project names.
      * @return A data object containing sets with projects

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BinaryFileParameterFactory/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BinaryFileParameterFactory/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:entry field="filePattern" title="${%File Pattern}">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Projects to build}" field="projects">
     <f:textbox />

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BlockingBehaviour/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BlockingBehaviour/config.jelly
@@ -22,6 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:getStatic var="failureConstant" className="hudson.model.Result" field="FAILURE"/>
   <j:getStatic var="unstableConstant" className="hudson.model.Result" field="UNSTABLE"/>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BooleanParameterConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BooleanParameterConfig/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry field="name" title="${%Name}">
     <f:textbox />

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BooleanParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BooleanParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="" field="configs">
     <f:repeatable field="configs" noAddButton="true" minimum="1">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTrigger/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Build Triggers}" field="configs">
     <f:repeatable field="configs" noAddButton="true" minimum="1">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildTriggerConfig/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Projects to build}" field="projects">
     <f:textbox autoCompleteDelimChar="," />

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/CounterBuildParameterFactory/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/CounterBuildParameterFactory/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:entry field="from" title="${%From}">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/CurrentBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/CurrentBuildParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry field="current" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameterFactory/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:entry field="filePattern" title="${%File Pattern}">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/FileBuildParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:entry field="propertiesFile" title="${%Use properties from file}">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/NodeAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/NodeAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 	<img width="16" height="16"
          title="${it.tooltip}"

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/NodeParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/NodeParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry field="current" />
 </j:jelly>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <f:entry field="properties" title="Parameters">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/ResultCondition/index.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/ResultCondition/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   ${it.displayName}
 </j:jelly>

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/SubversionRevisionBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/SubversionRevisionBuildParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry field="includeUpstreamParameters" title="${%Include/passthrough Upstream SVN Revisons}">
         <f:checkbox default="false" />

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/TriggerBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/TriggerBuilder/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Build Triggers}" field="configs">
     <f:repeatable field="configs" noAddButton="true" minimum="1">

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/matrix/MatrixSubsetBuildParameters/config.jelly
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/matrix/MatrixSubsetBuildParameters/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry field="filter" title="${%Groovy filter}">
     <f:textbox />

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CompatibilityTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CompatibilityTest.java
@@ -26,14 +26,22 @@ package hudson.plugins.parameterizedtrigger.test;
 import hudson.model.AbstractProject;
 import hudson.plugins.parameterizedtrigger.BuildTrigger;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class CompatibilityTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
 
+public class CompatibilityTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
 	@LocalData
+	@Test
 	public void test() throws Exception {
-		AbstractProject p = (AbstractProject) hudson.getItem("old");
+		AbstractProject p = (AbstractProject) r.jenkins.getItem("old");
 		BuildTrigger trigger = (BuildTrigger) p.getPublishersList().get(BuildTrigger.class);
 		assertEquals(2, trigger.getConfigs().size());
 	}

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/ConfigurationRoundtripTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/ConfigurationRoundtripTest.java
@@ -30,12 +30,20 @@ import hudson.plugins.parameterizedtrigger.CurrentBuildParameters;
 import hudson.plugins.parameterizedtrigger.FileBuildParameters;
 import hudson.plugins.parameterizedtrigger.ResultCondition;
 import hudson.plugins.parameterizedtrigger.SubversionRevisionBuildParameters;
-import org.jvnet.hudson.test.HudsonTestCase;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * @author Kohsuke Kawaguchi
  */
-public class ConfigurationRoundtripTest extends HudsonTestCase {
+public class ConfigurationRoundtripTest {
+    
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
     public void testConfigRoundtrip() throws Exception {
 /*  poorly written core breaks this test, so this is not yet testable.      
         FreeStyleProject p = createFreeStyleProject();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CounterBuildParameterFactoryTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CounterBuildParameterFactoryTest.java
@@ -14,17 +14,27 @@ import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.BlockingBehaviour;
 import hudson.plugins.parameterizedtrigger.CounterBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.TriggerBuilder;
-import org.jvnet.hudson.test.HudsonTestCase;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class CounterBuildParameterFactoryTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+public class CounterBuildParameterFactoryTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
     public void testWithOneParameter() throws Exception {
-        Project<?,?> projectA = createFreeStyleProject();
-        Project projectB = createFreeStyleProject();
+        Project<?,?> projectA = r.createFreeStyleProject();
+        Project projectB = r.createFreeStyleProject();
         projectA.getBuildersList().add(
                 new TriggerBuilder(
                         new BlockableBuildTriggerConfig(projectB.getName(),
@@ -35,10 +45,10 @@ public class CounterBuildParameterFactoryTest extends HudsonTestCase {
         CaptureAllEnvironmentBuilder builder = new CaptureAllEnvironmentBuilder();
         projectB.getBuildersList().add(builder);
         projectB.setQuietPeriod(0);
-        hudson.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
 
         projectA.scheduleBuild2(0, new Cause.UserCause()).get();
-        waitUntilNoActivity();
+        r.waitUntilNoActivity();
         List<FreeStyleBuild> builds = projectB.getBuilds();
         assertEquals(2, builds.size());
         Set<String> values = Sets.newHashSet();
@@ -50,9 +60,10 @@ public class CounterBuildParameterFactoryTest extends HudsonTestCase {
         assertEquals(ImmutableSet.of("COUNT0","COUNT1"), values);
     }
 
+    @Test
     public void testWithTwoParameters() throws Exception {
-        Project<?,?> projectA = createFreeStyleProject();
-        Project projectB = createFreeStyleProject();
+        Project<?,?> projectA = r.createFreeStyleProject();
+        Project projectB = r.createFreeStyleProject();
         projectA.getBuildersList().add(
                 new TriggerBuilder(
                         new BlockableBuildTriggerConfig(projectB.getName(),
@@ -67,10 +78,10 @@ public class CounterBuildParameterFactoryTest extends HudsonTestCase {
         CaptureAllEnvironmentBuilder builder = new CaptureAllEnvironmentBuilder();
         projectB.getBuildersList().add(builder);
         projectB.setQuietPeriod(0);
-        hudson.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
 
         projectA.scheduleBuild2(0, new Cause.UserCause()).get();
-        waitUntilNoActivity();
+        r.waitUntilNoActivity();
         List<FreeStyleBuild> builds = projectB.getBuilds();
         assertEquals(6, builds.size());
         Set<String> values = Sets.newHashSet();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CurrentBuildParametersTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CurrentBuildParametersTest.java
@@ -38,25 +38,36 @@ import hudson.plugins.parameterizedtrigger.TriggerBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 
-public class CurrentBuildParametersTest extends HudsonTestCase {
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+public class CurrentBuildParametersTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
 	public void test() throws Exception {
-		Project<?,?> projectA = createFreeStyleProject("projectA");
+		Project<?,?> projectA = r.createFreeStyleProject("projectA");
 		projectA.getPublishersList().add(
 				new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, new CurrentBuildParameters())));
 
 		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
-		Project projectB = createFreeStyleProject("projectB");
+		Project projectB = r.createFreeStyleProject("projectB");
 		projectB.getBuildersList().add(builder);
 		projectB.setQuietPeriod(1);
-		hudson.rebuildDependencyGraph();
+		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0, new UserCause(), new ParametersAction(
 			new StringParameterValue("KEY", "value"))).get();
-		hudson.getQueue().getItem(projectB).getFuture().get();
+		r.jenkins.getQueue().getItem(projectB).getFuture().get();
 
 		assertNotNull("builder should record environment", builder.getEnvVars());
 		assertEquals("value", builder.getEnvVars().get("KEY"));
@@ -81,6 +92,7 @@ public class CurrentBuildParametersTest extends HudsonTestCase {
 	 *
 	 * @throws Exception
 	 */
+    @Test
 	public void testPostBuildTriggerNoParametersWithoutParametersFalse() throws Exception {
 		testPostBuildTriggerNoParameters(false);
  	}
@@ -94,24 +106,25 @@ public class CurrentBuildParametersTest extends HudsonTestCase {
 	 *
 	 * @throws Exception
 	 */
+    @Test
 	public void testPostBuildTriggerNoParametersWithoutParametersTrue() throws Exception {
 		testPostBuildTriggerNoParameters(true);
  	}
 	
 	public void testPostBuildTriggerNoParameters(boolean pWithoutParameters) throws Exception {
-		Project<?,?> projectA = createFreeStyleProject("projectA");
+		Project<?,?> projectA = r.createFreeStyleProject("projectA");
 		List<AbstractBuildParameters> buildParameters = new ArrayList<AbstractBuildParameters>();
 		buildParameters.add(new CurrentBuildParameters());
 		projectA.getPublishersList().add(new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, pWithoutParameters, buildParameters)));
 		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
 
-		Project<?,?> projectB = createFreeStyleProject("projectB");
+		Project<?,?> projectB = r.createFreeStyleProject("projectB");
 		projectB.getBuildersList().add(builder);
 		projectB.setQuietPeriod(1);
-		hudson.rebuildDependencyGraph();
+		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0, new UserCause()).get();
-		assertEquals(pWithoutParameters, hudson.getQueue().contains(projectB));
+		assertEquals(pWithoutParameters, r.jenkins.getQueue().contains(projectB));
 		List<String> log = projectA.getLastBuild().getLog(20);
 		for (String string : log) {
 			System.out.println(string);
@@ -126,20 +139,21 @@ public class CurrentBuildParametersTest extends HudsonTestCase {
 	 *
 	 * @throws Exception
 	 */
+    @Test
 	public void testBuildStepTriggerBuildNoParameters() throws Exception {
-		Project<?,?> projectA = createFreeStyleProject("projectA");
+		Project<?,?> projectA = r.createFreeStyleProject("projectA");
 		List<AbstractBuildParameters> buildParameters = new ArrayList<AbstractBuildParameters>();
 		buildParameters.add(new CurrentBuildParameters());
 		projectA.getBuildersList().add(new TriggerBuilder(new BlockableBuildTriggerConfig("projectB", null, buildParameters)));
 		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
 
-		Project<?,?> projectB = createFreeStyleProject("projectB");
+		Project<?,?> projectB = r.createFreeStyleProject("projectB");
 		projectB.getBuildersList().add(builder);
 		projectB.setQuietPeriod(1);
-		hudson.rebuildDependencyGraph();
+		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0, new UserCause()).get();
-		assertTrue(hudson.getQueue().contains(projectB));
+		assertTrue(r.jenkins.getQueue().contains(projectB));
 		List<String> log = projectA.getLastBuild().getLog(20);
 		for (String string : log) {
 			System.out.println(string);

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/DefaultParameterValuesActionsTransformTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/DefaultParameterValuesActionsTransformTest.java
@@ -10,11 +10,21 @@ import hudson.plugins.parameterizedtrigger.DefaultParameterValuesActionsTransfor
 
 import java.io.IOException;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class DefaultParameterValuesActionsTransformTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class DefaultParameterValuesActionsTransformTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
     public void test() throws IOException {
-        Project project = createFreeStyleProject("project");
+        Project project = r.createFreeStyleProject("project");
 
         project.addProperty(new ParametersDefinitionProperty(
                     new StringParameterDefinition("key1", "value1"),

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/DontBuildTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/DontBuildTest.java
@@ -34,10 +34,18 @@ import hudson.plugins.parameterizedtrigger.ResultCondition;
 
 import java.io.IOException;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class DontBuildTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+public class DontBuildTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
 	public static final class DontBuildTrigger extends AbstractBuildParameters {
 		boolean called = false;
 		@Override
@@ -48,16 +56,17 @@ public class DontBuildTest extends HudsonTestCase {
 		}
 	}
 
+	@Test
 	public void test() throws Exception {
 
-		Project projectA = createFreeStyleProject("projectA");
+		Project projectA = r.createFreeStyleProject("projectA");
 		DontBuildTrigger dbt = new DontBuildTrigger();
 		projectA.getPublishersList().add(
 			new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, dbt)));
 
-		Project projectB = createFreeStyleProject("projectB");
+		Project projectB = r.createFreeStyleProject("projectB");
 		projectB.setQuietPeriod(0);
-		hudson.rebuildDependencyGraph();
+		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0).get();
 		Thread.sleep(1000);

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/PredefinedPropertiesBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/PredefinedPropertiesBuildTriggerConfigTest.java
@@ -29,35 +29,45 @@ import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.PredefinedBuildParameters;
 import hudson.plugins.parameterizedtrigger.ResultCondition;
 
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class PredefinedPropertiesBuildTriggerConfigTest extends HudsonTestCase {
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
+public class PredefinedPropertiesBuildTriggerConfigTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
 	public void test() throws Exception {
 
-		Project projectA = createFreeStyleProject("projectA");
+		Project projectA = r.createFreeStyleProject("projectA");
 		String properties = "KEY=value";
 		projectA.getPublishersList().add(
 				new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS,
 						new PredefinedBuildParameters(properties))));
 
 		CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
-		Project projectB = createFreeStyleProject("projectB");
+		Project projectB = r.createFreeStyleProject("projectB");
 		projectB.getBuildersList().add(builder);
 		projectB.setQuietPeriod(1);
-		hudson.rebuildDependencyGraph();
+		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0).get();
-		hudson.getQueue().getItem(projectB).getFuture().get();
+		r.jenkins.getQueue().getItem(projectB).getFuture().get();
 
 		assertNotNull("builder should record environment", builder.getEnvVars());
 		assertEquals("value", builder.getEnvVars().get("KEY"));
 	}
 	
+    @Test
     public void testNonAscii() throws Exception {
 
-        Project projectA = createFreeStyleProject("projectA");
+        Project projectA = r.createFreeStyleProject("projectA");
         String properties = "KEY=１２３\n" // 123 in multibytes
                 + "ＫＥＹ=value\n";    // "KEY" in multibytes
         projectA.getPublishersList().add(
@@ -65,13 +75,13 @@ public class PredefinedPropertiesBuildTriggerConfigTest extends HudsonTestCase {
                         new PredefinedBuildParameters(properties))));
 
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
-        Project projectB = createFreeStyleProject("projectB");
+        Project projectB = r.createFreeStyleProject("projectB");
         projectB.getBuildersList().add(builder);
         projectB.setQuietPeriod(1);
-        hudson.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
 
         projectA.scheduleBuild2(0).get();
-        hudson.getQueue().getItem(projectB).getFuture().get();
+        r.jenkins.getQueue().getItem(projectB).getFuture().get();
 
         assertNotNull("builder should record environment", builder.getEnvVars());
         assertEquals("１２３", builder.getEnvVars().get("KEY"));

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/ProjectSpecificParameterValuesActionTransformTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/ProjectSpecificParameterValuesActionTransformTest.java
@@ -4,18 +4,27 @@ import hudson.model.BooleanParameterDefinition;
 import hudson.model.BooleanParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
-import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 import hudson.model.Project;
 import hudson.plugins.parameterizedtrigger.ProjectSpecificParameterValuesActionTransform;
 
 import java.io.IOException;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class ProjectSpecificParameterValuesActionTransformTest extends HudsonTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ProjectSpecificParameterValuesActionTransformTest {
+    
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
     public void test() throws IOException {
-        Project project = createFreeStyleProject("project");
+        Project project = r.createFreeStyleProject("project");
 
         project.addProperty(new ParametersDefinitionProperty(
                     new BooleanParameterDefinition("key1", false, "derp")

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/RenameJobTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/RenameJobTest.java
@@ -46,22 +46,33 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import jenkins.model.Jenkins;
 import jenkins.model.ModifiableTopLevelItemGroup;
 
 import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
 import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
 import org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder;
 import org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockFolder;
 
-public class RenameJobTest extends HudsonTestCase {
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
+public class RenameJobTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
 	public void testRenameAndDeleteJobSingleProject() throws Exception {
-		FreeStyleProject projectA = createFreeStyleProject("projectA");
+		FreeStyleProject projectA = r.createFreeStyleProject("projectA");
 		configureTriggeringOf(projectA, "projectB");
-		Project<?,?> projectB = createFreeStyleProject("projectB");
-		hudson.rebuildDependencyGraph();
+		Project<?,?> projectB = r.createFreeStyleProject("projectB");
+		r.jenkins.rebuildDependencyGraph();
 
 		projectB.renameTo("projectB-renamed");
 
@@ -76,12 +87,13 @@ public class RenameJobTest extends HudsonTestCase {
 		assertNull("now-empty post build trigger should be removed", projectA.getPublishersList().get(BuildTrigger.class));
 	}
 
+    @Test
 	public void testRenameAndDeleteJobMultipleProjects() throws Exception {
-		Project<?,?> projectA = createFreeStyleProject("projectA");
+		Project<?,?> projectA = r.createFreeStyleProject("projectA");
 		configureTriggeringOf(projectA, "projectB", "projectC");
-		Project<?,?> projectB = createFreeStyleProject("projectB");
-		createFreeStyleProject("projectC");
-		hudson.rebuildDependencyGraph();
+		Project<?,?> projectB = r.createFreeStyleProject("projectB");
+		r.createFreeStyleProject("projectC");
+		r.jenkins.rebuildDependencyGraph();
 
 		projectB.renameTo("projectB-renamed");
 		
@@ -146,11 +158,12 @@ public class RenameJobTest extends HudsonTestCase {
     }
 
 	private <T extends TopLevelItem> T createProject(Class<T> type, ModifiableTopLevelItemGroup owner, String name) throws IOException {
-	    return (T) owner.createProject((TopLevelItemDescriptor) jenkins.getDescriptorOrDie(type), name, true);
+	    return (T) owner.createProject((TopLevelItemDescriptor) r.jenkins.getDescriptorOrDie(type), name, true);
 	}
 
+    @Test
     public void testRenameAndDeleteJobInSameFolder() throws Exception {
-        MockFolder folder1 = createProject(MockFolder.class, jenkins, "Folder1");
+        MockFolder folder1 = createProject(MockFolder.class, r.jenkins, "Folder1");
         FreeStyleProject p1 = createProject(FreeStyleProject.class, folder1, "ProjectA");
         FreeStyleProject p2 = createProject(FreeStyleProject.class, folder1, "ProjectB");
 
@@ -161,18 +174,18 @@ public class RenameJobTest extends HudsonTestCase {
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
         
-        jenkins.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
         
         // Test this works
         {
             assertNull(p2.getLastBuild());
             
-            buildAndAssertSuccess(p1);
+            r.buildAndAssertSuccess(p1);
             
-            jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
+            r.jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
             FreeStyleBuild b = p2.getLastBuild();
             assertNotNull(b);
-            assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(b);
             b.delete();
         }
         
@@ -190,12 +203,12 @@ public class RenameJobTest extends HudsonTestCase {
         {
             assertNull(p2.getLastBuild());
             
-            buildAndAssertSuccess(p1);
+            r.buildAndAssertSuccess(p1);
             
-            jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
+            r.jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
             FreeStyleBuild b = p2.getLastBuild();
             assertNotNull(b);
-            assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(b);
             b.delete();
         }
         
@@ -203,8 +216,9 @@ public class RenameJobTest extends HudsonTestCase {
         assertNull(p1.getPublishersList().get(BuildTrigger.class));
     }
 
+    @Test
     public void testRenameAndDeleteJobInSubFolder() throws Exception {
-        MockFolder folder1 = createProject(MockFolder.class, jenkins, "Folder1");
+        MockFolder folder1 = createProject(MockFolder.class, r.jenkins, "Folder1");
         MockFolder folder2 = createProject(MockFolder.class, folder1, "Folder2");
         FreeStyleProject p1 = createProject(FreeStyleProject.class, folder1, "ProjectA");
         FreeStyleProject p2 = createProject(FreeStyleProject.class, folder2, "ProjectB");
@@ -218,18 +232,18 @@ public class RenameJobTest extends HudsonTestCase {
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
         
-        jenkins.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
         
         // Test this works
         {
             assertNull(p2.getLastBuild());
             
-            buildAndAssertSuccess(p1);
+            r.buildAndAssertSuccess(p1);
             
-            jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
+            r.jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
             FreeStyleBuild b = p2.getLastBuild();
             assertNotNull(b);
-            assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(b);
             b.delete();
         }
         
@@ -247,12 +261,12 @@ public class RenameJobTest extends HudsonTestCase {
         {
             assertNull(p2.getLastBuild());
             
-            buildAndAssertSuccess(p1);
+            r.buildAndAssertSuccess(p1);
             
-            jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
+            r.jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
             FreeStyleBuild b = p2.getLastBuild();
             assertNotNull(b);
-            assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(b);
             b.delete();
         }
         
@@ -260,8 +274,9 @@ public class RenameJobTest extends HudsonTestCase {
         assertNull(p1.getPublishersList().get(BuildTrigger.class));
     }
 
+    @Test
     public void testRenameAndDeleteJobInParentFolder() throws Exception {
-        MockFolder folder1 = createProject(MockFolder.class, jenkins, "Folder1");
+        MockFolder folder1 = createProject(MockFolder.class, r.jenkins, "Folder1");
         MockFolder folder2 = createProject(MockFolder.class, folder1, "Folder2");
         FreeStyleProject p1 = createProject(FreeStyleProject.class, folder2, "ProjectA");
         FreeStyleProject p2 = createProject(FreeStyleProject.class, folder1, "ProjectB");
@@ -275,18 +290,18 @@ public class RenameJobTest extends HudsonTestCase {
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
         
-        jenkins.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
         
         // Test this works
         {
             assertNull(p2.getLastBuild());
             
-            buildAndAssertSuccess(p1);
+            r.buildAndAssertSuccess(p1);
             
-            jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
+            r.jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
             FreeStyleBuild b = p2.getLastBuild();
             assertNotNull(b);
-            assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(b);
             b.delete();
         }
         
@@ -304,12 +319,12 @@ public class RenameJobTest extends HudsonTestCase {
         {
             assertNull(p2.getLastBuild());
             
-            buildAndAssertSuccess(p1);
+            r.buildAndAssertSuccess(p1);
             
-            jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
+            r.jenkins.getQueue().getItem(p2).getFuture().get(60, TimeUnit.SECONDS);
             FreeStyleBuild b = p2.getLastBuild();
             assertNotNull(b);
-            assertBuildStatusSuccess(b);
+            r.assertBuildStatusSuccess(b);
             b.delete();
         }
         
@@ -318,17 +333,18 @@ public class RenameJobTest extends HudsonTestCase {
     }
     
     /**
-     * {@link hudson.model.Items#computeRelativeNamesAfterRenaming(String, String, String, hudson.model.ItemGroup)} has a bug
+     * {@link r.jenkins.model.Items#computeRelativeNamesAfterRenaming(String, String, String, r.jenkins.model.ItemGroup)} has a bug
      * that renaming names that contains the target name as prefix.
      * E.g. renaming ProjectB to ProjectB-renamed results in renaming ProjectB2 to ProjectB-renamed2.
      * This is fixed in Jenkins 1.530.
      * 
      * This test verifies this plugin is not affected by that problem.
-     */
+     */ 
+    @Test
     public void testComputeRelativeNamesAfterRenaming() throws Exception {
-        FreeStyleProject projectA = createFreeStyleProject("ProjectA");
-        FreeStyleProject projectB = createFreeStyleProject("ProjectB");
-        FreeStyleProject projectB2 = createFreeStyleProject("ProjectB2");
+        FreeStyleProject projectA = r.createFreeStyleProject("ProjectA");
+        FreeStyleProject projectB = r.createFreeStyleProject("ProjectB");
+        FreeStyleProject projectB2 = r.createFreeStyleProject("ProjectB2");
         
         projectA.getPublishersList().add(new BuildTrigger(new BuildTriggerConfig(
                 String.format("%s,%s", projectB.getName(), projectB2.getName()),
@@ -338,7 +354,7 @@ public class RenameJobTest extends HudsonTestCase {
                 Arrays.asList((AbstractBuildParameters)new CurrentBuildParameters())
         )));
         
-        jenkins.rebuildDependencyGraph();
+        r.jenkins.rebuildDependencyGraph();
         
         projectB.renameTo("ProjectB-renamed");
         

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/SubversionRevisionBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/SubversionRevisionBuildTriggerConfigTest.java
@@ -10,19 +10,24 @@ import hudson.plugins.parameterizedtrigger.ResultCondition;
 import hudson.plugins.parameterizedtrigger.SubversionRevisionBuildParameters;
 import hudson.scm.SubversionSCM;
 import hudson.scm.SubversionTagAction;
-import hudson.util.NullStream;
 
-import java.io.IOException;
-import java.io.PrintWriter;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.tmatesoft.svn.core.SVNException;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
-public class SubversionRevisionBuildTriggerConfigTest extends HudsonTestCase {
+public class SubversionRevisionBuildTriggerConfigTest {
 
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test @Ignore("https://groups.google.com/d/msg/jenkinsci-dev/8tLnOhHitKI/dCPJ53_wGAAJ")
 	public void testRevisionParameter() throws Exception {
-		FreeStyleProject p1 = createFreeStyleProject();
-		FreeStyleProject p2 = createFreeStyleProject();
+		FreeStyleProject p1 = r.createFreeStyleProject();
+		FreeStyleProject p2 = r.createFreeStyleProject();
 		p2.setQuietPeriod(1);
 
 		p1.setScm(new SubversionSCM(
@@ -34,11 +39,11 @@ public class SubversionRevisionBuildTriggerConfigTest extends HudsonTestCase {
 		p1.getPublishersList().add(
 				new BuildTrigger(new BuildTriggerConfig(p2.getName(), ResultCondition.SUCCESS,
 						new SubversionRevisionBuildParameters())));
-		hudson.rebuildDependencyGraph();
+		r.jenkins.rebuildDependencyGraph();
 
 		FreeStyleBuild b1 = p1.scheduleBuild2(0, new Cause.UserCause()).get();
-		Queue.Item q = hudson.getQueue().getItem(p2);
-		assertNotNull("p2 should be in queue (quiet period): " + getLog(b1), q);
+		Queue.Item q = r.jenkins.getQueue().getItem(p2);
+		assertNotNull("p2 should be in queue (quiet period): " + JenkinsRule.getLog(b1), q);
 		q.getFuture().get();
 
 		FreeStyleBuild b2 = p2.getLastBuild();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
@@ -25,7 +25,6 @@ package hudson.plugins.parameterizedtrigger.test;
 
 import hudson.model.*;
 import hudson.model.Cause.UpstreamCause;
-import hudson.model.queue.MappingWorksheet;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
@@ -36,7 +35,8 @@ import hudson.plugins.promoted_builds.PromotionProcess;
 import hudson.plugins.promoted_builds.conditions.DownstreamPassCondition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 
 import hudson.matrix.TextAxis;
@@ -53,34 +53,38 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.io.IOException;
 
-import org.jvnet.hudson.test.HudsonTestCase;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.System;
 
 import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class TriggerBuilderTest extends HudsonTestCase {
+public class TriggerBuilderTest {
 
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
     private BlockableBuildTriggerConfig createTriggerConfig(String projects) {
         return new BlockableBuildTriggerConfig(projects, new BlockingBehaviour("never", "never", "never"), null);
     }
 
+    @Test
     public void testOrderOfLogEntries() throws Exception {
-        createFreeStyleProject("project1");
-        createFreeStyleProject("project2");
-        createFreeStyleProject("project3");
-        createFreeStyleProject("project4");
-        createFreeStyleProject("project5");
-        createFreeStyleProject("project6");
+        r.createFreeStyleProject("project1");
+        r.createFreeStyleProject("project2");
+        r.createFreeStyleProject("project3");
+        r.createFreeStyleProject("project4");
+        r.createFreeStyleProject("project5");
+        r.createFreeStyleProject("project6");
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
 
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1"));
         triggerBuilder.getConfigs().add(createTriggerConfig("project2"));
@@ -102,20 +106,21 @@ public class TriggerBuilderTest extends HudsonTestCase {
                 "project6 #1 completed. Result was SUCCESS");
     }
 
+    @Test
     public void testSubParameterBuilds() throws Exception {
-        hudson.setNumExecutors(10); // makes sure there are enough executors so that there are no deadlocks
-        hudson.setNodes(hudson.getNodes()); // update nodes configuration (TODO https://github.com/jenkinsci/jenkins/pull/1596 renders this workaround unnecessary)
+        r.jenkins.setNumExecutors(10); // makes sure there are enough executors so that there are no deadlocks
+        r.jenkins.setNodes(r.jenkins.getNodes()); // update nodes configuration (TODO https://github.com/jenkinsci/jenkins/pull/1596 renders this workaround unnecessary)
 
-        FreeStyleProject p1 = createFreeStyleProject("project1");
-        createFreeStyleProject("project2");
-        createFreeStyleProject("project3");
+        FreeStyleProject p1 = r.createFreeStyleProject("project1");
+        r.createFreeStyleProject("project2");
+        r.createFreeStyleProject("project3");
 
         ///triggered from project 1
-        createFreeStyleProject("projectZ4");
-        createFreeStyleProject("projectZ5");
-        createFreeStyleProject("projectZ6");
+        r.createFreeStyleProject("projectZ4");
+        r.createFreeStyleProject("projectZ5");
+        r.createFreeStyleProject("projectZ6");
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
 
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1"));
         triggerBuilder.getConfigs().add(createTriggerConfig("project2"));
@@ -135,12 +140,13 @@ public class TriggerBuilderTest extends HudsonTestCase {
             "project3 #1 completed. Result was SUCCESS");
     }
 
+    @Test
     public void testWaitingForCompletion() throws Exception {
-        createFreeStyleProject("project1");
-        createFreeStyleProject("project2");
-        createFreeStyleProject("project3");
+        r.createFreeStyleProject("project1");
+        r.createFreeStyleProject("project2");
+        r.createFreeStyleProject("project3");
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
 
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1, project2, project3"));
 
@@ -154,12 +160,13 @@ public class TriggerBuilderTest extends HudsonTestCase {
                 "Waiting for the completion of project3");
     }
 
+    @Test
     public void testNonBlockingTrigger() throws Exception {
-        createFreeStyleProject("project1");
-        createFreeStyleProject("project2");
-        createFreeStyleProject("project3");
+        r.createFreeStyleProject("project1");
+        r.createFreeStyleProject("project2");
+        r.createFreeStyleProject("project3");
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
 
         BlockableBuildTriggerConfig config = new BlockableBuildTriggerConfig("project1, project2, project3", null, null);
         TriggerBuilder triggerBuilder = new TriggerBuilder(config);
@@ -172,12 +179,13 @@ public class TriggerBuilderTest extends HudsonTestCase {
                 "Triggering projects: project1, project2, project3");
     }
 
+    @Test
     public void testConsoleOutputWithCounterParameters() throws Exception{
-        createFreeStyleProject("project1");
-        createFreeStyleProject("project2");
-        createFreeStyleProject("project3");
+        r.createFreeStyleProject("project1");
+        r.createFreeStyleProject("project2");
+        r.createFreeStyleProject("project3");
 
-        Project<?,?> triggerProject = createFreeStyleProject();
+        Project<?,?> triggerProject = r.createFreeStyleProject();
 
         BlockingBehaviour blockingBehaviour = new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE);
         ImmutableList<AbstractBuildParameterFactory> buildParameter = ImmutableList.<AbstractBuildParameterFactory>of(new CounterBuildParameterFactory("0", "2", "1", "TEST=COUNT$COUNT"));
@@ -201,14 +209,14 @@ public class TriggerBuilderTest extends HudsonTestCase {
                 "project3 #3 completed. Result was SUCCESS");
     }
 
-
+    @Test
     public void testBlockingTriggerWithDisabledProjects() throws Exception {
-        createFreeStyleProject("project1");
-        Project<?, ?> p2 = createFreeStyleProject("project2");
+        r.createFreeStyleProject("project1");
+        Project<?, ?> p2 = r.createFreeStyleProject("project2");
         p2.disable();
-        createFreeStyleProject("project3");
+        r.createFreeStyleProject("project3");
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
 
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1, project2, project3"));
 
@@ -223,11 +231,12 @@ public class TriggerBuilderTest extends HudsonTestCase {
     }
 
     /** Verify that workflow build can be triggered */
+    @Test
     public void testTriggerWithWorkflow() throws Exception {
         WorkflowJob p = (WorkflowJob) Jenkins.getInstance().createProject(WorkflowJob.class, "project1");
         p.setDefinition(new CpsFlowDefinition("println('hello')"));
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1"));
         triggerProject.getBuildersList().add(triggerBuilder);
         triggerProject.scheduleBuild2(0).get();
@@ -239,12 +248,13 @@ public class TriggerBuilderTest extends HudsonTestCase {
 
     /** Verify that getProjectsList works with workflow and normal projects */
     @Issue("JENKINS-30040")
+    @Test
     public void testGetProjectsList() throws Exception {
         WorkflowJob p = (WorkflowJob) Jenkins.getInstance().createProject(WorkflowJob.class, "project1");
         p.setDefinition(new CpsFlowDefinition("println('hello')"));
-        Project<?, ?> p2 = createFreeStyleProject("project2");
+        Project<?, ?> p2 = r.createFreeStyleProject("project2");
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1"));
         triggerProject.getBuildersList().add(triggerBuilder);
 
@@ -252,17 +262,18 @@ public class TriggerBuilderTest extends HudsonTestCase {
         jobs.add(p);
         jobs.add(p2);
         String projectListAsString = triggerBuilder.getProjectListAsString(jobs);
-        assertStringContains(projectListAsString, "project1");
-        assertStringContains(projectListAsString, "project2");
+        r.assertStringContains(projectListAsString, "project1");
+        r.assertStringContains(projectListAsString, "project2");
     }
 
     /** Verify that workflow build can be triggered with normal project too */
+    @Test
     public void testTriggerWithWorkflowMixedTypes() throws Exception {
-        createFreeStyleProject("project1");
+        r.createFreeStyleProject("project1");
         WorkflowJob p = (WorkflowJob) Jenkins.getInstance().createProject(WorkflowJob.class, "project2");
         p.setDefinition(new CpsFlowDefinition("println('hello')"));
 
-        Project<?, ?> triggerProject = createFreeStyleProject("projectA");
+        Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
         TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("project1, project2"));
         triggerProject.getBuildersList().add(triggerBuilder);
         triggerProject.scheduleBuild2(0).get();
@@ -273,6 +284,7 @@ public class TriggerBuilderTest extends HudsonTestCase {
     }
 
     @Bug(14278)
+    @Test
     public void testBlockingTriggerWithMatrixProject() throws Exception {
 
         /* This test case will start a matrix project that is configured with 2 Axis
@@ -289,15 +301,15 @@ public class TriggerBuilderTest extends HudsonTestCase {
          * Set as 50 for first case.
          */
 
-        hudson.setNumExecutors(50);
-        hudson.setNodes(hudson.getNodes()); // update nodes configuration
+        r.jenkins.setNumExecutors(50);
+        r.jenkins.setNodes(r.jenkins.getNodes()); // update nodes configuration
 
-        createFreeStyleProject("project1");
-        createFreeStyleProject("project2");
-        createFreeStyleProject("project3");
-        createFreeStyleProject("project4");
-        createFreeStyleProject("project5");
-        createFreeStyleProject("project6");
+        r.createFreeStyleProject("project1");
+        r.createFreeStyleProject("project2");
+        r.createFreeStyleProject("project3");
+        r.createFreeStyleProject("project4");
+        r.createFreeStyleProject("project5");
+        r.createFreeStyleProject("project6");
 
         MatrixProject matrixProject = createMatrixProject("matrixProject");
 
@@ -331,6 +343,7 @@ public class TriggerBuilderTest extends HudsonTestCase {
     }
 
     @Bug(17751)
+    @Test
     public void testTriggerFromPromotion() throws Exception {
         assertNotNull("promoted-builds must be installed.", Jenkins.getInstance().getPlugin("promoted-builds"));
         // Test combination with PromotedBuilds.
@@ -338,9 +351,9 @@ public class TriggerBuilderTest extends HudsonTestCase {
         // The configuration is as following:
         // Project1 -> (built-in trigger) -> Project2
         //          -> (promotion) -> Project1/Promotion/TRIGGER -> (Parameterrized Trigger) -> Project3
-        FreeStyleProject project1 = createFreeStyleProject();
-        FreeStyleProject project2 = createFreeStyleProject();
-        FreeStyleProject project3 = createFreeStyleProject();
+        FreeStyleProject project1 = r.createFreeStyleProject();
+        FreeStyleProject project2 = r.createFreeStyleProject();
+        FreeStyleProject project3 = r.createFreeStyleProject();
         
         // project1 -> project2
         project1.getPublishersList().add(new hudson.tasks.BuildTrigger(project2.getName(), "SUCCESS"));
@@ -416,18 +429,17 @@ public class TriggerBuilderTest extends HudsonTestCase {
             }
         }
         
-        assertBuildStatusSuccess(project1_build);
-        assertBuildStatusSuccess(project2_build);
-        assertBuildStatusSuccess(project3_build);
+        r.assertBuildStatusSuccess(project1_build);
+        r.assertBuildStatusSuccess(project2_build);
+        r.assertBuildStatusSuccess(project3_build);
         
         UpstreamCause c = project3_build.getCause(UpstreamCause.class);
         assertNotNull(String.format("Failed to get UpstreamCause from project3(%s)", project3.getName()), c);
         assertEquals("UpstreamCause is not properly set.", project1.getName(), c.getUpstreamProject());
     }
 
-    @Override
     protected MatrixProject createMatrixProject(String name) throws IOException {
-        MatrixProject p = super.createMatrixProject(name);
+        MatrixProject p = r.createProject(MatrixProject.class, name);
         // set up 2x2 matrix
         AxisList axes = new AxisList();
         axes.add(new TextAxis("db","mysql","oracle"));
@@ -437,26 +449,27 @@ public class TriggerBuilderTest extends HudsonTestCase {
         return p;
     }
 
+    @Test
     public void testExpansionOfMultipleProjectsInEnvVariable() throws Exception {
-        FreeStyleProject upstream = createFreeStyleProject();
+        FreeStyleProject upstream = r.createFreeStyleProject();
         upstream.addProperty(new ParametersDefinitionProperty(
                 new StringParameterDefinition("PARAM", "downstream1,downstream2")
         ));
 
-        FreeStyleProject downstream1 = createFreeStyleProject("downstream1");
-        FreeStyleProject downstream2 = createFreeStyleProject("downstream2");
+        FreeStyleProject downstream1 = r.createFreeStyleProject("downstream1");
+        FreeStyleProject downstream2 = r.createFreeStyleProject("downstream2");
         BlockableBuildTriggerConfig config = new BlockableBuildTriggerConfig("${PARAM}", null, null);
         TriggerBuilder triggerBuilder = new TriggerBuilder(config);
 
         upstream.getBuildersList().add(triggerBuilder);
 
         FreeStyleBuild upstreamBuild = upstream.scheduleBuild2(0, new Cause.UserCause(), new ParametersAction(new StringParameterValue("PARAM", "downstream1,downstream2"))).get();
-        assertBuildStatusSuccess(upstreamBuild);
-        waitUntilNoActivity();
+        r.assertBuildStatusSuccess(upstreamBuild);
+        r.waitUntilNoActivity();
         FreeStyleBuild downstream1Build = downstream1.getLastBuild();
         FreeStyleBuild downstream2Build = downstream2.getLastBuild();
-        assertBuildStatusSuccess(downstream1Build);
-        assertBuildStatusSuccess(downstream2Build);
+        r.assertBuildStatusSuccess(downstream1Build);
+        r.assertBuildStatusSuccess(downstream2Build);
     }
 
     private void assertLines(Run<?,?> build, String... lines) throws IOException {


### PR DESCRIPTION
Superseeds (and includes) #97 

Work included:

- [x] Upgrade to parent pom 2.7
- [x] Fix test errors
- [x] Fix javadoc errors
- [x] Update tests to use `JenkinsRule` instead of `HudsonTestCase`
- [x] Bump baseline to 1.596.1. Reason [here](https://cloudbees.zendesk.com/hc/en-us/articles/204170674-After-updating-Matrix-Project-Plugin-Jenkins-fails-to-restart-)

@reviewbybees @kwhetstone