### PR TITLE
Fix Method not Allowed errors during svn checkout

### DIFF
--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/SubversionRevisionBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/SubversionRevisionBuildTriggerConfigTest.java
@@ -26,10 +26,10 @@ public class SubversionRevisionBuildTriggerConfigTest extends HudsonTestCase {
 		p2.setQuietPeriod(1);
 
 		p1.setScm(new SubversionSCM(
-					"https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant@13000"));
+					"svn://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant@13000"));
 
 		p2.setScm(new SubversionSCM(
-					"https://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant"));
+					"svn://svn.jenkins-ci.org/trunk/hudson/test-projects/trivial-ant"));
 
 		p1.getPublishersList().add(
 				new BuildTrigger(new BuildTriggerConfig(p2.getName(), ResultCondition.SUCCESS,


### PR DESCRIPTION
svn.jenkins-ci.org doesn't seem to support https checkout anymore. Building against the latest svn plugin doesn't work either. Changing the checkout protocol in SubversionRevisionBuildTriggerConfigTest to svn:// fixes it.  Local machine clone using svn, version 1.9.3 has the same behavior. 