### PR TITLE
branch/show-subprojects-links-during-build

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
@@ -8,6 +8,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.Cause.UpstreamCause;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.model.Hudson;
 import hudson.model.Job;
 import hudson.model.Node;
@@ -56,21 +57,21 @@ public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
     }
 
     @Override
-    public ListMultimap<AbstractProject, Future<AbstractBuild>> perform2(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        ListMultimap<AbstractProject, Future<AbstractBuild>> futures = super.perform2(build, launcher, listener);
+    public ListMultimap<AbstractProject, QueueTaskFuture<? extends AbstractBuild<?,?>>> perform2(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        ListMultimap<AbstractProject, QueueTaskFuture<? extends AbstractBuild<?,?>>> futures = super.perform2(build, launcher, listener);
         if(block==null) return ArrayListMultimap.create();
         return futures;
     }
 
     @Override
-    public ListMultimap<Job, Future<Run>> perform3(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        ListMultimap<Job, Future<Run>> futures = super.perform3(build, launcher, listener);
+    public ListMultimap<Job, QueueTaskFuture<? extends AbstractBuild<?,?>>> perform3(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        ListMultimap<Job, QueueTaskFuture<? extends AbstractBuild<?,?>>> futures = super.perform3(build, launcher, listener);
         if(block==null) return ArrayListMultimap.create();
         return futures;
     }
 
     @Override
-    protected Future schedule(AbstractBuild<?, ?> build, Job project, List<Action> list, TaskListener listener) throws InterruptedException, IOException {
+    protected QueueTaskFuture<? extends AbstractBuild<?, ?>> schedule(AbstractBuild<?, ?> build, Job project, List<Action> list, TaskListener listener) throws InterruptedException, IOException {
         if (block!=null) {
             while (true) {
                 // add DifferentiatingAction to make sure this doesn't get merged with something else,
@@ -79,7 +80,7 @@ public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
 
                 // if we fail to add the item to the queue, wait and retry.
                 // it also means we have to force quiet period = 0, or else it'll never leave the queue
-                Future f = schedule(build, project, 0, list, listener);
+                QueueTaskFuture<? extends AbstractBuild<?, ?>> f = schedule(build, project, 0, list, listener);
                 // When a project is disabled or the configuration is not yet saved f will always be null and we're caught in a loop, therefore we need to check for it
                 if (f!=null || (f==null && !canBeScheduled(project))){
                     return f;

--- a/src/main/java/hudson/plugins/parameterizedtrigger/Plugin.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/Plugin.java
@@ -1,10 +1,14 @@
 package hudson.plugins.parameterizedtrigger;
 
 import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
+import hudson.model.Items;
 import hudson.model.Project;
 import hudson.model.listeners.ItemListener;
+import hudson.plugins.parameterizedtrigger.BuildInfoExporterAction.StaticBuildReference;
 import hudson.util.EnumConverter;
 
 import java.io.IOException;
@@ -27,6 +31,7 @@ public class Plugin extends hudson.Plugin {
 	public void start() throws Exception {
 		Stapler.CONVERT_UTILS.register(new EnumConverter(),
 				ResultCondition.class);
+	  Items.XSTREAM2.addCompatibilityAlias("hudson.plugins.parameterizedtrigger.BuildInfoExporterAction$BuildReference", StaticBuildReference.class);
 	}
 
         /**

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -147,7 +147,7 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
                                     listener.getLogger().println("Waiting for the completion of " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
                                     Run b = future.get();
                                     listener.getLogger().println(HyperlinkNote.encodeTo('/' + b.getUrl(), b.getFullDisplayName()) + " completed. Result was " + b.getResult());
-                                    BuildInfoExporterAction.addBuildInfoExporterAction(build, b.getParent().getFullName(), b.getNumber(), b.getResult());
+                                    BuildInfoExporterAction.addBuildInfoExporterAction(build, future);
 
                                     if (buildStepResult && config.getBlock().mapBuildStepResult(b.getResult())) {
                                         build.setResult(config.getBlock().mapBuildResult(b.getResult()));

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -42,6 +42,7 @@ import hudson.tasks.Builder;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.User;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.util.IOException2;
 import jenkins.model.DependencyDeclarer;
 import org.kohsuke.accmod.Restricted;
@@ -90,7 +91,7 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
 
         try {
             for (BlockableBuildTriggerConfig config : configs) {
-                ListMultimap<Job, Future<Run>> futures = config.perform3(build, launcher, listener);
+                ListMultimap<Job, QueueTaskFuture<? extends AbstractBuild<?,?>>> futures = config.perform3(build, launcher, listener);
                 // Only contains resolved projects
                 List<Job> projectList = config.getJobs(build.getRootBuild().getProject().getParent(), env);
 
@@ -140,7 +141,7 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
                                     + " or the configuration has not been saved yet.");
                             continue;
                         }
-                        for (Future<Run> future : futures.get(p)) {
+                        for (QueueTaskFuture<? extends AbstractBuild<?,?>> future : futures.get(p)) {
                             try {
                                 if (future != null ) {
                                     listener.getLogger().println("Waiting for the completion of " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
@@ -28,6 +28,7 @@ import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.*;
 import hudson.model.Cause.UpstreamCause;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
@@ -91,7 +92,7 @@ public class TriggerBuilderTest {
         when(config.getProjects(any(EnvVars.class))).thenReturn(disabledJob.getName());
         when(config.getBlock()).thenReturn(new BlockingBehaviour(Result.FAILURE, Result.FAILURE, Result.FAILURE));
 
-        final ArrayListMultimap<Job, Future<Run>> futures = ArrayListMultimap.create();
+        final ArrayListMultimap<Job, QueueTaskFuture<? extends AbstractBuild<?,?>>> futures = ArrayListMultimap.create();
         when(config.perform3(any(AbstractBuild.class),
                 Mockito.any(Launcher.class),
                 Mockito.any(BuildListener.class))).thenReturn(futures);


### PR DESCRIPTION
This branch changes the information presented in the upstream build while it's waiting for the triggered downstream projects to finish.

The goal is reached by using the QueueTaskFutures for polling status of the triggered builds. As soon as a build is started the id of the build (which is not available until it is queue) is registered in the BuildInfoExporterAction. 

The polling is done every 15 seconds.
