### PR TITLE
TriggerBuilder now implements DependencyDeclarer

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -34,6 +34,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.DependencyGraph;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
@@ -177,7 +178,7 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer{
         for (BuildTriggerConfig config : configs) {
             List<AbstractProject> projectList = config.getProjectList(owner.getParent(), null);
             for (AbstractProject project : projectList) {
-                ParameterizedDependency.add(owner, project, config, graph);
+                graph.addDependency(new TriggerBuilderDependency(owner, project, config));
             }
         }
     }
@@ -199,6 +200,17 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer{
     @Override
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
         return ImmutableList.of(new SubProjectsAction(project, configs));
+    }
+
+    public static class TriggerBuilderDependency extends ParameterizedDependency {
+        public TriggerBuilderDependency(AbstractProject upstream, AbstractProject downstream, BuildTriggerConfig config) {
+            super(upstream, downstream, config);
+        }
+
+        @Override
+        public boolean shouldTriggerBuild(AbstractBuild build, TaskListener listener, List<Action> actions) {
+            return false;
+        }
     }
 
     @Extension


### PR DESCRIPTION
Certain plugins doesn't work when triggering builds
of other projects as build steps, i.e. using TriggerBuilder.
When triggering as a post build step, i.e. using BuildTrigger,
this works. Two examples are the Junit plugin, when aggregating
test results from downstream builds and the downstream build view.

The reason is that BuildTrigger builds up a correct
DependencyGraph and TriggerBuilder does not.

This change remedies this by using the same mechanism as BuildTrigger.
