### PR TITLE
Fix NPE in case of race condition

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -134,15 +134,17 @@ public class TriggerBuilder extends Builder {
                         }
                         for (Future<Run> future : futures.get(p)) {
                             try {
-                                listener.getLogger().println("Waiting for the completion of " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
-                                Run b = future.get();
-                                listener.getLogger().println(HyperlinkNote.encodeTo('/'+ b.getUrl(), b.getFullDisplayName()) + " completed. Result was "+b.getResult());
-                                BuildInfoExporterAction.addBuildInfoExporterAction(build, b.getParent().getFullName(), b.getNumber(), b.getResult());
+                                if (future != null ) {
+                                    listener.getLogger().println("Waiting for the completion of " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
+                                    Run b = future.get();
+                                    listener.getLogger().println(HyperlinkNote.encodeTo('/' + b.getUrl(), b.getFullDisplayName()) + " completed. Result was " + b.getResult());
+                                    BuildInfoExporterAction.addBuildInfoExporterAction(build, b.getParent().getFullName(), b.getNumber(), b.getResult());
 
-                                if(buildStepResult && config.getBlock().mapBuildStepResult(b.getResult())) {
-                                    build.setResult(config.getBlock().mapBuildResult(b.getResult()));
-                                } else {
-                                    buildStepResult = false;
+                                    if (buildStepResult && config.getBlock().mapBuildStepResult(b.getResult())) {
+                                        build.setResult(config.getBlock().mapBuildResult(b.getResult()));
+                                    } else {
+                                        buildStepResult = false;
+                                    }
                                 }
                             } catch (CancellationException x) {
                                 throw new AbortException(p.getFullDisplayName() +" aborted.");

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -145,6 +145,8 @@ public class TriggerBuilder extends Builder {
                                     } else {
                                         buildStepResult = false;
                                     }
+                                } else {
+                                    listener.getLogger().println("Skipping " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()) + ". The project was disabled.");
                                 }
                             } catch (CancellationException x) {
                                 throw new AbortException(p.getFullDisplayName() +" aborted.");

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -146,7 +146,7 @@ public class TriggerBuilder extends Builder {
                                         buildStepResult = false;
                                     }
                                 } else {
-                                    listener.getLogger().println("Skipping " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()) + ". The project was disabled.");
+                                    listener.getLogger().println("Skipping " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()) + ". The project was not triggered by some reason.");
                                 }
                             } catch (CancellationException x) {
                                 throw new AbortException(p.getFullDisplayName() +" aborted.");


### PR DESCRIPTION
NPE happens in rare case:
1) We have X projects
2) We disabled one of them
3) Trigger fired X-1 projects and filled map <projectName, executor>
4) Job was fixed, and we enable this job again
5) Trigger is waiting for all projects (now it's X projects again)
6) It tries to access job that we re-enabled -> it doesn't exist in map => NPE

How it looks like in logs:
```
Waiting for the completion of projectA
projectA #22344 completed. Result was SUCCESS
Waiting for the completion of projectB
ERROR: Build step failed with exception
java.lang.NullPointerException
Build step 'Trigger/call builds on other projects' marked build as failure
```

I failed to create test case for it :( .Because those two lines are too close to each other:
```
ListMultimap<Job, Future<Run>> futures = config.perform3(build, launcher, listener); // contains config.getJobs as well.
List<Job> projectList = config.getJobs(build.getRootBuild().getProject().getParent(), env);
```

In perfect world I would prefer different solution - take list of projects and provide this list to `perform3` step. But it needs much more changes and usually maintainers are not so happy to merge so complicated stuff :)