### PR TITLE
Fix extra comma error in list of projects

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -646,7 +646,7 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
             while(tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
                 if (StringUtils.isBlank(projectName)) {
-                    return FormValidation.error(Messages.BuildTrigger_NoSuchProject(" ", "?"));
+                    return FormValidation.error("Blank project name in the list");
                 }
 
                 Item item = Jenkins.getInstance().getItem(projectName,project,Item.class); // only works after version 1.410

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -669,7 +669,6 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
                 }
 
                 hasProjects = true;
-
             }
             if (!hasProjects) {
             	return FormValidation.error(Messages.BuildTrigger_NoProjectSpecified());

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -645,28 +645,31 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
             boolean hasProjects = false;
             while(tokens.hasMoreTokens()) {
                 String projectName = tokens.nextToken().trim();
-                if (StringUtils.isNotBlank(projectName)) {
-                	Item item = Jenkins.getInstance().getItem(projectName,project,Item.class); // only works after version 1.410
-                    if(item==null){
-                        Item nearest = Items.findNearest(Job.class, projectName, Jenkins.getInstance());
-                        String alternative = nearest != null ? nearest.getRelativeNameFrom(project) : "?";
-                        return FormValidation.error(Messages.BuildTrigger_NoSuchProject(projectName, alternative));
-                    }
-                    if(!(item instanceof Job) || !(item instanceof ParameterizedJobMixIn.ParameterizedJob)) {
-                        return FormValidation.error(Messages.BuildTrigger_NotBuildable(projectName));
-                    }
-
-                    // check whether the supposed user is expected to be able to build
-                    Authentication auth = Tasks.getAuthenticationOf((ParameterizedJobMixIn.ParameterizedJob)project);
-                    if (auth.equals(ACL.SYSTEM) && !QueueItemAuthenticatorConfiguration.get().getAuthenticators().isEmpty()) {
-                        auth = Jenkins.ANONYMOUS;
-                    }
-                    if (!item.getACL().hasPermission(auth, Item.BUILD)) {
-                        return FormValidation.error(Messages.BuildTrigger_you_have_no_permission_to_build_(projectName));
-                    }
-
-                    hasProjects = true;
+                if (StringUtils.isBlank(projectName)) {
+                    return FormValidation.error(Messages.BuildTrigger_NoSuchProject(" ", "?"));
                 }
+
+                Item item = Jenkins.getInstance().getItem(projectName,project,Item.class); // only works after version 1.410
+                if(item==null){
+                    Item nearest = Items.findNearest(Job.class, projectName, Jenkins.getInstance());
+                    String alternative = nearest != null ? nearest.getRelativeNameFrom(project) : "?";
+                    return FormValidation.error(Messages.BuildTrigger_NoSuchProject(projectName, alternative));
+                }
+                if(!(item instanceof Job) || !(item instanceof ParameterizedJobMixIn.ParameterizedJob)) {
+                    return FormValidation.error(Messages.BuildTrigger_NotBuildable(projectName));
+                }
+
+                // check whether the supposed user is expected to be able to build
+                Authentication auth = Tasks.getAuthenticationOf((ParameterizedJobMixIn.ParameterizedJob)project);
+                if (auth.equals(ACL.SYSTEM) && !QueueItemAuthenticatorConfiguration.get().getAuthenticators().isEmpty()) {
+                    auth = Jenkins.ANONYMOUS;
+                }
+                if (!item.getACL().hasPermission(auth, Item.BUILD)) {
+                    return FormValidation.error(Messages.BuildTrigger_you_have_no_permission_to_build_(projectName));
+                }
+
+                hasProjects = true;
+
             }
             if (!hasProjects) {
             	return FormValidation.error(Messages.BuildTrigger_NoProjectSpecified());

--- a/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
@@ -68,8 +68,8 @@ public class ParameterizedTriggerUtils {
         }
     }
     
-        /**
-     * {@link read VirtualFile
+    /**
+     * {@link} read VirtualFile
      * 
      * @param f file to read
      * @return read string

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
@@ -336,7 +336,7 @@ public class BuildTriggerConfigTest {
     }
 
     @Test
-    public void testExtraCommaInConfig() throws Exception {
+    public void testBlankProjectNameInConfig() throws Exception {
         Project<?, ?> masterProject = r.createFreeStyleProject("project");
 
         FormValidation form = r.jenkins.getDescriptorByType(BuildTriggerConfig.DescriptorImpl.class).doCheckProjects(masterProject, "project, ");

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
@@ -43,6 +43,7 @@ import hudson.security.ACL;
 import hudson.security.AuthorizationMatrixProperty;
 import hudson.security.Permission;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -307,4 +308,39 @@ public class BuildTriggerConfigTest {
 
     }
 
+    @Test
+    public void testBlankConfig() throws Exception {
+        Project<?, ?> masterProject = r.createFreeStyleProject("project");
+
+        FormValidation form = r.jenkins.getDescriptorByType(BuildTriggerConfig.DescriptorImpl.class).doCheckProjects(masterProject, "");
+
+        assertEquals(FormValidation.Kind.ERROR, form.kind);
+    }
+
+    @Test
+    public void testNonExistedProject() throws Exception {
+        Project<?, ?> masterProject = r.createFreeStyleProject("project");
+
+        FormValidation form = r.jenkins.getDescriptorByType(BuildTriggerConfig.DescriptorImpl.class).doCheckProjects(masterProject, "nonExistedProject");
+
+        assertEquals(FormValidation.Kind.ERROR, form.kind);
+    }
+
+    @Test
+    public void testValidConfig() throws Exception {
+        Project<?, ?> masterProject = r.createFreeStyleProject("project");
+
+        FormValidation form = r.jenkins.getDescriptorByType(BuildTriggerConfig.DescriptorImpl.class).doCheckProjects(masterProject, "project");
+
+        assertEquals(FormValidation.Kind.OK, form.kind);
+    }
+
+    @Test
+    public void testExtraCommaInConfig() throws Exception {
+        Project<?, ?> masterProject = r.createFreeStyleProject("project");
+
+        FormValidation form = r.jenkins.getDescriptorByType(BuildTriggerConfig.DescriptorImpl.class).doCheckProjects(masterProject, "project, ");
+
+        assertEquals(FormValidation.Kind.ERROR, form.kind);
+    }
 }


### PR DESCRIPTION
Right now user can provide list of project with extra comma. I.e. `"projectA, "`
And verification passes.

But after execution user receives:
```
ERROR: Build aborted. Can't trigger undefined projects. 1 of the below project(s) can't be resolved:
 > 
 > projectA
Check your configuration!
```

It happens because in `TriggerBuilder.java` we have check like this:
```
// Get the actual defined projects
StringTokenizer tokenizer = new StringTokenizer(config.getProjects(env), ",");
...
if (tokenizer.countTokens() != projectList.size()) {
```

And as result number of tokens are bigger than number of projects (because we skipped empty one before). So, I adjust this check with the most earliest existed check I found.