### PR TITLE
plugin compat tester fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,7 @@
     </pluginRepositories>
     
     <properties>
-      <jenkins.version>1.638</jenkins.version>
-      <java.level>6</java.level>
+      <jenkins.version>1.642.3</jenkins.version>
       <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>matrix-auth</artifactId>
-	      <version>1.3.2</version>
+	      <version>1.4</version>
 	      <scope>test</scope>
         </dependency>
         <dependency>
@@ -128,12 +128,6 @@
 	            <artifactId>hamcrest-core</artifactId>
              </exclusion>
           </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>cloudbees-folder</artifactId>
-	      <version>5.18</version>
-	      <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -158,7 +152,7 @@
     </pluginRepositories>
     
     <properties>
-      <jenkins.version>1.637</jenkins.version>
+      <jenkins.version>1.638</jenkins.version>
       <java.level>6</java.level>
       <findbugs.failOnError>false</findbugs.failOnError>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.7</version>
+        <version>2.23</version>
     </parent>
     
     <licenses>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10</version>
+            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -100,6 +100,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>matrix-auth</artifactId>
 	      <version>1.3.2</version>
@@ -116,6 +128,12 @@
 	            <artifactId>hamcrest-core</artifactId>
              </exclusion>
           </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>cloudbees-folder</artifactId>
+	      <version>5.18</version>
+	      <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -140,7 +158,7 @@
     </pluginRepositories>
     
     <properties>
-      <jenkins.version>1.596.1</jenkins.version>
+      <jenkins.version>1.637</jenkins.version>
       <java.level>6</java.level>
       <findbugs.failOnError>false</findbugs.failOnError>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -78,19 +78,25 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.27</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -134,7 +140,6 @@
     </pluginRepositories>
     
     <properties>
-      <workflow.version>1.4</workflow.version>
       <jenkins.version>1.596.1</jenkins.version>
       <java.level>6</java.level>
       <findbugs.failOnError>false</findbugs.failOnError>

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
@@ -181,7 +181,7 @@ public class BuildTriggerConfigTest {
     @Test
     public void testBuildWithWorkflowProjects() throws Exception {
         Project<?, ?> masterProject = r.createFreeStyleProject("project");
-        WorkflowJob workflowProject = Jenkins.getInstance().createProject(WorkflowJob.class, "workflowproject");
+        WorkflowJob workflowProject = r.createProject(WorkflowJob.class, "workflowproject");
         workflowProject.setDefinition(new CpsFlowDefinition("node { echo myParam; }"));
         // SECURITY-170: must define parameters in subjobs
         List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
@@ -29,7 +29,10 @@ import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
+import hudson.model.StringParameterDefinition;
 import hudson.model.User;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
@@ -180,6 +183,10 @@ public class BuildTriggerConfigTest {
         Project<?, ?> masterProject = r.createFreeStyleProject("project");
         WorkflowJob workflowProject = Jenkins.getInstance().createProject(WorkflowJob.class, "workflowproject");
         workflowProject.setDefinition(new CpsFlowDefinition("node { echo myParam; }"));
+        // SECURITY-170: must define parameters in subjobs
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("myParam","myParam"));
+        workflowProject.addProperty(new ParametersDefinitionProperty(definition));
 
         // Trigger a normal and workflow project
         String projectToTrigger = "subproject1, workflowproject";
@@ -196,6 +203,7 @@ public class BuildTriggerConfigTest {
 
         Project subProject1 = r.createFreeStyleProject("subproject1");
         subProject1.setQuietPeriod(0);
+        subProject1.addProperty(new ParametersDefinitionProperty(definition));
 
         masterProject.scheduleBuild2(0, new Cause.UserCause()).get();
 

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CounterBuildParameterFactoryTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CounterBuildParameterFactoryTest.java
@@ -6,7 +6,10 @@ import com.google.common.collect.Sets;
 import hudson.EnvVars;
 import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
+import hudson.model.StringParameterDefinition;
 import hudson.model.Result;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
@@ -19,6 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -45,6 +49,10 @@ public class CounterBuildParameterFactoryTest {
         CaptureAllEnvironmentBuilder builder = new CaptureAllEnvironmentBuilder();
         projectB.getBuildersList().add(builder);
         projectB.setQuietPeriod(0);
+        // SECURITY-170: must define parameters in subjobs
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("TEST","test"));
+        projectB.addProperty(new ParametersDefinitionProperty(definition));
         r.jenkins.rebuildDependencyGraph();
 
         projectA.scheduleBuild2(0, new Cause.UserCause()).get();
@@ -78,6 +86,11 @@ public class CounterBuildParameterFactoryTest {
         CaptureAllEnvironmentBuilder builder = new CaptureAllEnvironmentBuilder();
         projectB.getBuildersList().add(builder);
         projectB.setQuietPeriod(0);
+        // SECURITY-170: must define parameters in subjobs
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("TEST","test"));
+        definition.add(new StringParameterDefinition("NEWTEST","newtest"));
+        projectB.addProperty(new ParametersDefinitionProperty(definition));
         r.jenkins.rebuildDependencyGraph();
 
         projectA.scheduleBuild2(0, new Cause.UserCause()).get();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CurrentBuildParametersTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CurrentBuildParametersTest.java
@@ -25,7 +25,10 @@ package hudson.plugins.parameterizedtrigger.test;
 
 import hudson.model.Cause.UserCause;
 import hudson.model.ParametersAction;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
@@ -56,6 +59,10 @@ public class CurrentBuildParametersTest {
     @Test
 	public void test() throws Exception {
 		Project<?,?> projectA = r.createFreeStyleProject("projectA");
+		// SECURITY-170: must define parameters in subjobs
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("KEY","key"));
+		projectA.addProperty(new ParametersDefinitionProperty(definition));
 		projectA.getPublishersList().add(
 				new BuildTrigger(new BuildTriggerConfig("projectB", ResultCondition.SUCCESS, new CurrentBuildParameters())));
 
@@ -63,6 +70,7 @@ public class CurrentBuildParametersTest {
 		Project projectB = r.createFreeStyleProject("projectB");
 		projectB.getBuildersList().add(builder);
 		projectB.setQuietPeriod(1);
+        projectB.addProperty(new ParametersDefinitionProperty(definition));
 		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0, new UserCause(), new ParametersAction(

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
@@ -42,9 +42,11 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.ParameterValue;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
+import hudson.model.ParameterDefinition;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
 import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
 import hudson.model.labels.LabelExpression;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
@@ -66,6 +68,9 @@ import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SingleFileSCM;
 import org.jvnet.hudson.test.ExtractResourceSCM;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -127,7 +132,7 @@ public class FileBuildTriggerConfigTest {
         definition.add(new StringParameterDefinition("A_TEST_03","test3"));
         definition.add(new StringParameterDefinition("Z_TEST_01","test1"));
         definition.add(new StringParameterDefinition("Z_TEST_02","test2"));
-        workflowProject.addProperty(new ParametersDefinitionProperty(definition));
+        projectB.addProperty(new ParametersDefinitionProperty(definition));
 		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0).get();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildTriggerConfigTest.java
@@ -130,8 +130,8 @@ public class FileBuildTriggerConfigTest {
         definition.add(new StringParameterDefinition("A_TEST_01","test1"));
         definition.add(new StringParameterDefinition("A_TEST_02","test2"));
         definition.add(new StringParameterDefinition("A_TEST_03","test3"));
-        definition.add(new StringParameterDefinition("Z_TEST_01","test1"));
-        definition.add(new StringParameterDefinition("Z_TEST_02","test2"));
+        definition.add(new StringParameterDefinition("Z_TEST_100","test1"));
+        definition.add(new StringParameterDefinition("Z_TEST_101","test2"));
         projectB.addProperty(new ParametersDefinitionProperty(definition));
 		r.jenkins.rebuildDependencyGraph();
 
@@ -192,6 +192,9 @@ public class FileBuildTriggerConfigTest {
 
         // SECURITY-170: need to allow multibyte params that can't be traditionally declared.
         try {
+            //System.setProperty(ParametersAction.KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, "true");
+            System.setProperty("hudson.model.ParametersAction.keepUndefinedParameters", "true");
+
             projectA.scheduleBuild2(0).get();
             r.jenkins.getQueue().getItem(projectB).getFuture().get();
 
@@ -226,6 +229,9 @@ public class FileBuildTriggerConfigTest {
 
         // SECURITY-170: need to allow multibyte params that can't be traditionally declared.
         try {
+            //System.setProperty(ParametersAction.KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, "true");
+            System.setProperty("hudson.model.ParametersAction.keepUndefinedParameters", "true");
+
             projectA.scheduleBuild2(0).get();
             r.jenkins.getQueue().getItem(projectB).getFuture().get();
 
@@ -260,6 +266,9 @@ public class FileBuildTriggerConfigTest {
 
         // SECURITY-170: need to allow multibyte params that can't be traditionally declared.
         try {
+            //System.setProperty(ParametersAction.KEEP_UNDEFINED_PARAMETERS_SYSTEM_PROPERTY_NAME, "true");
+            System.setProperty("hudson.model.ParametersAction.keepUndefinedParameters", "true");
+
             projectA.scheduleBuild2(0).get();
             r.jenkins.getQueue().getItem(projectB).getFuture().get();
 

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/PredefinedPropertiesBuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/PredefinedPropertiesBuildTriggerConfigTest.java
@@ -23,7 +23,10 @@
  */
 package hudson.plugins.parameterizedtrigger.test;
 
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
+import hudson.model.StringParameterDefinition;
 import hudson.plugins.parameterizedtrigger.BuildTrigger;
 import hudson.plugins.parameterizedtrigger.BuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.PredefinedBuildParameters;
@@ -36,6 +39,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PredefinedPropertiesBuildTriggerConfigTest {
 
@@ -55,6 +61,10 @@ public class PredefinedPropertiesBuildTriggerConfigTest {
 		Project projectB = r.createFreeStyleProject("projectB");
 		projectB.getBuildersList().add(builder);
 		projectB.setQuietPeriod(1);
+        // SECURITY-170: must define parameters in subjobs
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("KEY","key"));
+        projectB.addProperty(new ParametersDefinitionProperty(definition));
 		r.jenkins.rebuildDependencyGraph();
 
 		projectA.scheduleBuild2(0).get();
@@ -78,6 +88,11 @@ public class PredefinedPropertiesBuildTriggerConfigTest {
         Project projectB = r.createFreeStyleProject("projectB");
         projectB.getBuildersList().add(builder);
         projectB.setQuietPeriod(1);
+        // SECURITY-170: must define parameters in subjobs
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("KEY","key"));
+        definition.add(new StringParameterDefinition("ＫＥＹ","otherkey"));
+        projectB.addProperty(new ParametersDefinitionProperty(definition));
         r.jenkins.rebuildDependencyGraph();
 
         projectA.scheduleBuild2(0).get();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
@@ -268,7 +268,7 @@ public class TriggerBuilderTest {
     /** Verify that workflow build can be triggered */
     @Test
     public void testTriggerWithWorkflow() throws Exception {
-        WorkflowJob p = (WorkflowJob) Jenkins.getInstance().createProject(WorkflowJob.class, "project1");
+        WorkflowJob p = (WorkflowJob) r.createProject(WorkflowJob.class, "project1");
         p.setDefinition(new CpsFlowDefinition("println('hello')"));
 
         Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");
@@ -285,7 +285,7 @@ public class TriggerBuilderTest {
     @Issue("JENKINS-30040")
     @Test
     public void testGetProjectsList() throws Exception {
-        WorkflowJob p = (WorkflowJob) Jenkins.getInstance().createProject(WorkflowJob.class, "project1");
+        WorkflowJob p = (WorkflowJob) r.createProject(WorkflowJob.class, "project1");
         p.setDefinition(new CpsFlowDefinition("println('hello')"));
         Project<?, ?> p2 = r.createFreeStyleProject("project2");
 
@@ -305,7 +305,7 @@ public class TriggerBuilderTest {
     @Test
     public void testTriggerWithWorkflowMixedTypes() throws Exception {
         r.createFreeStyleProject("project1");
-        WorkflowJob p = (WorkflowJob) Jenkins.getInstance().createProject(WorkflowJob.class, "project2");
+        WorkflowJob p = (WorkflowJob) r.createProject(WorkflowJob.class, "project2");
         p.setDefinition(new CpsFlowDefinition("println('hello')"));
 
         Project<?, ?> triggerProject = r.createFreeStyleProject("projectA");


### PR DESCRIPTION
With the new changes to the plugin compatibility tester, a few of this plugin's tests fail.  The plugin compat tester tests a plugin against the newest version of it's dependencies as if it's been installed on the newest version of Jenkins.  This led to some failures even though when running tests on the current Jenkins version were no issues.

Currently this depends on the 1.x line of the workflow plugins.  Since there were significant changes with this plugin upon the 2.x release, I updated them and included new plugins that replicate the old functionality.  Also, I bumped the plugin-pom version as well as matirx-auth to get out of the "break-cycles" issue.  I had to bump the jenkins.version to 1.638 for missing pieces for the new workflow plugins.  That's the lowest version that I could move to.  However, it might be worth going to the next LTS for stability.

I also had to address the many SECURITY-170 violations that underpined many of the tests.  SECURITY-170 really targeted this plugin, so I had to change the tests to reflect that.  This also makes the tests future proof when we actually depend on versions above 2.3.

 I have run all the parameterized-trigger tests using mvn test as well as through the plugin compat tester, and there are now no errors.

@reviewbybees