### PR TITLE
TriggerBuilder now implements DependencyDeclarer

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -155,7 +155,6 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer {
 
 	@Override
 	public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
-		// Can only add dependencies in Hudson 1.341 or higher
 		if (!canDeclare(owner)) return;
 
 		for (BuildTriggerConfig config : configs) {
@@ -179,13 +178,9 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer {
 	}
 
 	private boolean canDeclare(AbstractProject owner) {
-        // In Hudson 1.341+ builds will be triggered via DependencyGraph
-        // Inner class added in Hudson 1.341
-        String ownerClassName = owner.getClass().getName();
-		return DependencyGraph.class.getClasses().length > 0
-                        // See HUDSON-5679 -- dependency graph is also not used when triggered from a promotion
-                        && !ownerClassName.equals("hudson.plugins.promoted_builds.PromotionProcess");
- 	}
+		// See HUDSON-5679 -- dependency graph is also not used when triggered from a promotion
+		return !owner.getClass().getName().equals("hudson.plugins.promoted_builds.PromotionProcess");
+	}
 
 	@Extension
 	public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -190,17 +190,12 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
     }
 
     private boolean canDeclare(AbstractProject owner) {
-        // In Hudson 1.341+ builds will be triggered via DependencyGraph
-        // Inner class added in Hudson 1.341
-        String ownerClassName = owner.getClass().getName();
-        return DependencyGraph.class.getClasses().length > 0
-                // See HUDSON-5679 -- dependency graph is also not used when triggered from a promotion
-                && !ownerClassName.equals("hudson.plugins.promoted_builds.PromotionProcess");
+        // See HUDSON-5679 -- dependency graph is also not used when triggered from a promotion
+        return !owner.getClass().getName().equals("hudson.plugins.promoted_builds.PromotionProcess");
     }
 
     @Override
     public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
-        // Can only add dependencies in Hudson 1.341 or higher
         if (!canDeclare(owner)) return;
 
         for (BuildTriggerConfig config : configs) {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -34,6 +34,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.DependencyGraph;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
@@ -41,6 +42,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.User;
 import hudson.util.IOException2;
+import jenkins.model.DependencyDeclarer;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -55,7 +57,7 @@ import java.util.concurrent.Future;
  *
  * @author Kohsuke Kawaguchi
  */
-public class TriggerBuilder extends Builder {
+public class TriggerBuilder extends Builder implements DependencyDeclarer {
 
     private final ArrayList<BlockableBuildTriggerConfig> configs;
 
@@ -185,6 +187,28 @@ public class TriggerBuilder extends Builder {
     @Override
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
         return ImmutableList.of(new SubProjectsAction(project, configs));
+    }
+
+    private boolean canDeclare(AbstractProject owner) {
+        // In Hudson 1.341+ builds will be triggered via DependencyGraph
+        // Inner class added in Hudson 1.341
+        String ownerClassName = owner.getClass().getName();
+        return DependencyGraph.class.getClasses().length > 0
+                // See HUDSON-5679 -- dependency graph is also not used when triggered from a promotion
+                && !ownerClassName.equals("hudson.plugins.promoted_builds.PromotionProcess");
+    }
+
+    @Override
+    public void buildDependencyGraph(AbstractProject owner, DependencyGraph graph) {
+        // Can only add dependencies in Hudson 1.341 or higher
+        if (!canDeclare(owner)) return;
+
+        for (BuildTriggerConfig config : configs) {
+            List<AbstractProject> projectList = config.getProjectList(owner.getParent(), null);
+            for (AbstractProject project : projectList) {
+                ParameterizedDependency.add(owner, project, config, graph);
+            }
+        }
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -35,6 +35,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
 import hudson.model.DependencyGraph;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Builder;
@@ -183,7 +184,6 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
         return projectListString.toString();
     }
 
-
     @Override
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
         return ImmutableList.of(new SubProjectsAction(project, configs));
@@ -206,8 +206,19 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
         for (BuildTriggerConfig config : configs) {
             List<AbstractProject> projectList = config.getProjectList(owner.getParent(), null);
             for (AbstractProject project : projectList) {
-                ParameterizedDependency.add(owner, project, config, graph);
+                graph.addDependency(new TriggerBuilderDependency(owner, project, config));
             }
+        }
+    }
+
+    public static class TriggerBuilderDependency extends ParameterizedDependency {
+        public TriggerBuilderDependency(AbstractProject upstream, AbstractProject downstream, BuildTriggerConfig config) {
+            super(upstream, downstream, config);
+        }
+
+        @Override
+        public boolean shouldTriggerBuild(AbstractBuild build, TaskListener listener, List<Action> actions) {
+            return false;
         }
     }
 


### PR DESCRIPTION
Continuation from #109. See this PR for previous discussions.

My colleague is on parental leave, but I'll continue the work one this fork. The code has now been rebased against master. A test cases has been added that shows that a downstream project is indeed triggered twice if shouldTriggerBuild() does not return false.

This pull request fixes visualization of plugins like Downstream View Plugin and other issues like JUnit test result aggregation, where a graph of triggered projects is typically traversed.