### PR TITLE
Make multiline parameter when newlines are present with indirect value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,4 +209,3 @@
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
 </project>
-

--- a/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/PredefinedBuildParameters.java
@@ -24,7 +24,6 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 	private final String properties;
 	private final boolean textParamValueOnNewLine;
 
-
 	@DataBoundConstructor
 	public PredefinedBuildParameters(String properties, boolean textParamValueOnNewLine) {
 		this.properties = properties;
@@ -35,7 +34,8 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 		this(properties, false);
 	}
 
-	public Action getAction(AbstractBuild<?,?> build, TaskListener listener)
+	@Override
+	public Action getAction(AbstractBuild<?, ?> build, TaskListener listener)
 			throws IOException, InterruptedException {
 
 		EnvVars env = getEnvironment(build, listener);
@@ -45,11 +45,11 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 		List<ParameterValue> values = new ArrayList<>();
 		for (Map.Entry<Object, Object> entry : p.entrySet()) {
 			// support multi-line parameters correctly
-			String s = entry.getValue().toString();
-			if(textParamValueOnNewLine && s.contains("\n")) {
-				values.add(new TextParameterValue(entry.getKey().toString(), env.expand(s)));
+			String s = env.expand(entry.getValue().toString());
+			if (textParamValueOnNewLine && s.contains("\n")) {
+				values.add(new TextParameterValue(entry.getKey().toString(), s));
 			} else {
-				values.add(new StringParameterValue(entry.getKey().toString(), env.expand(s)));
+				values.add(new StringParameterValue(entry.getKey().toString(), s));
 			}
 		}
 
@@ -66,6 +66,7 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 
 	@Extension
 	public static class DescriptorImpl extends Descriptor<AbstractBuildParameters> {
+
 		@Override
 		public String getDisplayName() {
 			return "Predefined parameters";


### PR DESCRIPTION
When user defines a multiline parameter:

![image](https://user-images.githubusercontent.com/475781/39133266-13901b7e-4714-11e8-8b94-d8adde175f26.png)

then passes this parameter downstream as B=$X:

![image](https://user-images.githubusercontent.com/475781/39133323-3b491c74-4714-11e8-9f8c-da2097feecbf.png)

then the parameter information in the downstream job is not rendered as multiline:

![image](https://user-images.githubusercontent.com/475781/39133371-5179690e-4714-11e8-9f13-b05a9e9f29f9.png)

Direct root cause is the check for embedded newline character before expanding parameter value. This pull request fixes the behavior by expanding the string before newline check. I have also added a unit test for this scenario.

As a side note: I am not sure why there is a checkbox for the user to create TextParameterValue instead of StringParameterValue. I believe that it should always be rendered as TextParameterValue; there is no point to present this option to user, especially since this is implementation detail and is totally meaningless for the end user.