### PR TITLE
[JENKINS-57472] Keep node label even if machine disconnects

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/NodeParameters.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/NodeParameters.java
@@ -27,13 +27,13 @@ public class NodeParameters extends AbstractBuildParameters{
 
 	@Override
 	public Action getAction(AbstractBuild<?, ?> build, TaskListener listener) throws IOException, InterruptedException, DontTriggerException {
-		Node node = build.getBuiltOn();
+		String nodeName = build.getBuiltOnStr();
 		Label nodeLabel;
 		// master does not return a node name so add it explicitly.
-		if(node == null) {
+		if(nodeName == null || nodeName == "") {
 			nodeLabel = Jenkins.getInstance().getSelfLabel();
 		} else {
-			nodeLabel = node.getSelfLabel();
+			nodeLabel = Label.get(nodeName);
 		}
 		listener.getLogger().println("Returning node parameter for " + nodeLabel.getDisplayName());
 		return new NodeAction(nodeLabel);


### PR DESCRIPTION
### SUMMARY

Proposed fix for https://issues.jenkins-ci.org/browse/JENKINS-57472.

### DETAILS

If the build machine running the project disconnects while it is running (causing the build to be aborted), then calling `getBuiltOn()` will result in returning _null_ (because this function is asking the Jenkins instance to get the node with the built on label, which no longer exists).  This null incorrectly causes the plugin to build the triggered project on master (potentially with disastrous results).

This PR changes the code snippet to use `getBuiltOnStr()` instead, which returns the node label string.  If _this_ is null or empty string, then it is safe to assume we were built on master; if not, we'll convert the node label string directly into a label and return it, without asking the Jenkins instance to find the corresponding node.

### TESTS

I've been experimenting with adding a unit test for the new functionality, but have limited experience with the test harness and haven't been able to recreate the initial case (where the build agent disconnects before Project A completes, then Project A triggers Project B).  I'm open to that if someone has ideas.

I am currently manually testing on Jenkins 2.138.2.