### PR TITLE
[JENKINS-57442]: print link to running job

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
@@ -18,6 +18,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -49,28 +50,28 @@ public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
     }
 
     @Override
-    public List<Future<AbstractBuild>> perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        List<Future<AbstractBuild>> r = super.perform(build, launcher, listener);
+    public List<QueueTaskFuture<AbstractBuild>> perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        List<QueueTaskFuture<AbstractBuild>> r = super.perform(build, launcher, listener);
         if (block==null) return Collections.emptyList();
         return r;
     }
 
     @Override
-    public ListMultimap<AbstractProject, Future<AbstractBuild>> perform2(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        ListMultimap<AbstractProject, Future<AbstractBuild>> futures = super.perform2(build, launcher, listener);
+    public ListMultimap<AbstractProject, QueueTaskFuture<AbstractBuild>> perform2(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        ListMultimap<AbstractProject, QueueTaskFuture<AbstractBuild>> futures = super.perform2(build, launcher, listener);
         if(block==null) return ArrayListMultimap.create();
         return futures;
     }
 
     @Override
-    public ListMultimap<Job, Future<Run>> perform3(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        ListMultimap<Job, Future<Run>> futures = super.perform3(build, launcher, listener);
+    public ListMultimap<Job, QueueTaskFuture<AbstractBuild>> perform3(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        ListMultimap<Job, QueueTaskFuture<AbstractBuild>> futures = super.perform3(build, launcher, listener);
         if(block==null) return ArrayListMultimap.create();
         return futures;
     }
 
     @Override
-    protected Future schedule(AbstractBuild<?, ?> build, Job project, List<Action> list, TaskListener listener) throws InterruptedException, IOException {
+    protected QueueTaskFuture schedule(AbstractBuild<?, ?> build, Job project, List<Action> list, TaskListener listener) throws InterruptedException, IOException {
         if (block!=null) {
             while (true) {
                 // add DifferentiatingAction to make sure this doesn't get merged with something else,
@@ -79,7 +80,7 @@ public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
 
                 // if we fail to add the item to the queue, wait and retry.
                 // it also means we have to force quiet period = 0, or else it'll never leave the queue
-                Future f = schedule(build, project, 0, list, listener);
+                QueueTaskFuture f = schedule(build, project, 0, list, listener);
                 // When a project is disabled or the configuration is not yet saved f will always be null and we're caught in a loop, therefore we need to check for it
                 if (f!=null || (f==null && !canBeScheduled(project))){
                     return f;

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -15,6 +15,7 @@ import hudson.model.DependencyGraph;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -104,8 +105,8 @@ public class BuildTrigger extends Notifier implements DependecyDeclarer {
 			for (BuildTriggerConfig config : configs) {
 				if (!alreadyFired.contains(config)) {
 					//config.perform(build, launcher, listener);
-					List<Future<AbstractBuild>> futures = config.perform(build, launcher, listener);
-					for (Future future : futures) {
+					List<QueueTaskFuture<AbstractBuild>> futures = config.perform(build, launcher, listener);
+					for (QueueTaskFuture future : futures) {
 						AbstractBuild abstractBuild = null;
 						try {
 							abstractBuild = (AbstractBuild) future.get();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
@@ -46,13 +46,13 @@ import hudson.matrix.TextAxis;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.MatrixRun;
 import hudson.matrix.AxisList;
+import hudson.model.queue.QueueTaskFuture;
 
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.io.IOException;
@@ -91,11 +91,11 @@ public class TriggerBuilderTest {
         when(config.getProjects(any(EnvVars.class))).thenReturn(disabledJob.getName());
         when(config.getBlock()).thenReturn(new BlockingBehaviour(Result.FAILURE, Result.FAILURE, Result.FAILURE));
 
-        final ArrayListMultimap<Job, Future<Run>> futures = ArrayListMultimap.create();
+        final ArrayListMultimap<Job, QueueTaskFuture<AbstractBuild>> futures = ArrayListMultimap.create();
         when(config.perform3(any(AbstractBuild.class),
                 Mockito.any(Launcher.class),
                 Mockito.any(BuildListener.class))).thenReturn(futures);
-        // Then project is disabled scheduler returns null instead of Future<Run> object
+        // Then project is disabled scheduler returns null instead of QueueTaskFuture<Run> object
         futures.put(disabledJob, null);
 
         final List<Job> jobs = new ArrayList<Job>();
@@ -134,11 +134,17 @@ public class TriggerBuilderTest {
         triggerProject.scheduleBuild2(0).get();
 
         assertLines(triggerProject.getLastBuild(),
+                "project1 #1 started.",
                 "project1 #1 completed. Result was SUCCESS",
+                "project2 #1 started.",
                 "project2 #1 completed. Result was SUCCESS",
+                "project3 #1 started.",
                 "project3 #1 completed. Result was SUCCESS",
+                "project4 #1 started.",
                 "project4 #1 completed. Result was SUCCESS",
+                "project5 #1 started.",
                 "project5 #1 completed. Result was SUCCESS",
+                "project6 #1 started.",
                 "project6 #1 completed. Result was SUCCESS");
     }
 
@@ -171,8 +177,11 @@ public class TriggerBuilderTest {
 
         triggerProject.scheduleBuild2(0).get();
         assertLines(triggerProject.getLastBuild(),
+            "project1 #1 started.",
             "project1 #1 completed. Result was SUCCESS",
+            "project2 #1 started.",
             "project2 #1 completed. Result was SUCCESS",
+            "project3 #1 started.",
             "project3 #1 completed. Result was SUCCESS");
     }
 
@@ -234,14 +243,23 @@ public class TriggerBuilderTest {
         triggerProject.scheduleBuild2(0).get();
 
         assertLines(triggerProject.getLastBuild(),
+                "project1 #1 started.",
                 "project1 #1 completed. Result was SUCCESS",
+                "project1 #2 started.",
                 "project1 #2 completed. Result was SUCCESS",
+                "project1 #3 started.",
                 "project1 #3 completed. Result was SUCCESS",
+                "project2 #1 started.",
                 "project2 #1 completed. Result was SUCCESS",
+                "project2 #2 started.",
                 "project2 #2 completed. Result was SUCCESS",
+                "project2 #3 started.",
                 "project2 #3 completed. Result was SUCCESS",
+                "project3 #1 started.",
                 "project3 #1 completed. Result was SUCCESS",
+                "project3 #2 started.",
                 "project3 #2 completed. Result was SUCCESS",
+                "project3 #3 started.",
                 "project3 #3 completed. Result was SUCCESS");
     }
 


### PR DESCRIPTION
This makes it much easier to find the child job while it
is running and not yet finished.

This is implemented with QueueTaskFuture's waitForStart()
method that returns the job once it starts running. The Future
waited on was already an instance of QueueTaskFuture, but
I needed to plumb through the type instead of the Future
interface.

Testing:
* Added checks to a couple of unit tests for the new log lines.
* Ran unit tests.
* Tested plugin on a production jenkins instance.