### PR TITLE
Removed debug print causing printout in jenkins log

### DIFF
--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
@@ -29,7 +29,6 @@ if (projects.size() > 0) {
 	ul(style:"list-style-type: none;") {
 		for (item in projects) {
 			li {
-				print "${item}"
 				if (item != null) {
 					a(href:"${rootURL}/${item.url}", class:"model-link") {
 						text(item.displayName)


### PR DESCRIPTION
The innocent looking print() call actually ends up in the Jenkins log
and not in the outputted HTML sent via the browser. To output content
to the webbrowser text() should be used, and is used a few lines later.

This print out causes a lot of pain on our servers as everytime someone loads a build page it spams our system log with debug information, e.g.:
```
INFO: a_upstream #1 main build action completed: SUCCESS
hudson.model.FreeStyleProject@50635a73[a_downstream]Jul 17, 2019 2:08:30 PM hudson.model.Run execute
INFO: a_downstream #1 main build action completed: SUCCESS
hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]hudson.model.FreeStyleProject@50635a73[a_downstream]
```