### PR TITLE
Feature: System property ptp.disableActionViews disables summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This plugin lets you trigger new builds when your build has completed, with vari
 
 See the documentation and release notes at [Parameterized Trigger Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Parameterized+Trigger+Plugin) on the Jenkins Wiki for more information.
 
-
-
-
+Note: Set Java property "ptp.disableActionViews" (typically Launch Jenkins with -Dptp.disableActionViews) to stop the listing of
+"Sub Projects" on the build and project main pages. This can be of use when other plugins are used to render the upstream/downstream
+flow and there is reduntant information displayed about the triggered builds.

--- a/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
@@ -40,6 +40,8 @@ import jenkins.util.VirtualFile;
  * Common utility methods.
  */
 public class ParameterizedTriggerUtils {
+    public static final String DISABLE_ACTION_VIEWS_KEY = "ptp.disableActionViews";
+
     /**
      * Load properties from string.
      *

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
@@ -1,5 +1,11 @@
 package hudson.plugins.parameterizedtrigger.BuildInfoExporterAction
 
+import static hudson.plugins.parameterizedtrigger.ParameterizedTriggerUtils.DISABLE_ACTION_VIEWS_KEY
+
+if (System.getProperty(DISABLE_ACTION_VIEWS_KEY) != null) {
+	return
+}
+
 def builds = my.triggeredBuilds
 if(builds.size() > 0) {
 	h2("Subproject Builds")

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicBuildAction/summary.groovy
@@ -1,5 +1,11 @@
 package hudson.plugins.parameterizedtrigger.DynamicBuildAction
 
+import static hudson.plugins.parameterizedtrigger.ParameterizedTriggerUtils.DISABLE_ACTION_VIEWS_KEY
+
+if (System.getProperty(DISABLE_ACTION_VIEWS_KEY) != null) {
+    return
+}
+
 def acts = my.builds
 if (!acts.empty) {
     h2(_("Dynamic downstream projects"))

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicProjectAction/jobMain.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/DynamicProjectAction/jobMain.groovy
@@ -1,5 +1,11 @@
 package hudson.plugins.parameterizedtrigger.DynamicProjectAction
 
+import static hudson.plugins.parameterizedtrigger.ParameterizedTriggerUtils.DISABLE_ACTION_VIEWS_KEY
+
+if (System.getProperty(DISABLE_ACTION_VIEWS_KEY) != null) {
+    return
+}
+
 def acts = my.projects
 if (!acts.empty) {
     h2(_("Dynamic downstream projects"))

--- a/src/main/resources/hudson/plugins/parameterizedtrigger/SubProjectsAction/jobMain.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/SubProjectsAction/jobMain.groovy
@@ -2,6 +2,12 @@ package hudson.plugins.parameterizedtrigger.SubProjectsAction
 
 import hudson.Functions
 
+import static hudson.plugins.parameterizedtrigger.ParameterizedTriggerUtils.DISABLE_ACTION_VIEWS_KEY
+
+if (System.getProperty(DISABLE_ACTION_VIEWS_KEY) != null) {
+    return
+}
+
 def j=namespace(lib.JenkinsTagLib)
 
 def actions = my.subProjectActions


### PR DESCRIPTION
Set Java property "ptp.disableActionViews" (typically Launch Jenkins
with -Dptp.disableActionViews) to stop the listing of "Sub Projects"
on the build and project main pages. This can be of use when other
plugins are used to render the upstream/downstream flow and there is
reduntant information displayed about the triggered builds.