### PR TITLE
Use GitHub as a source of documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <packaging>hpi</packaging>
     <version>2.35.3-SNAPSHOT</version>
     <name>Jenkins Parameterized Trigger plugin</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Parameterized+Trigger+Plugin</url>
+    <url>https://github.com/jenkinsci/parameterized-trigger-plugin</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
Forgot to change it in #131 