### PR TITLE
[JENKINS-57507] Recover from orphaned labels

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/NodeAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/NodeAction.java
@@ -34,23 +34,29 @@ import hudson.model.queue.SubTask;
 import java.util.List;
 
 /**
- * {@link Action} that restricts the job to a particular node 
+ * {@link Action} that restricts the job to a particular node
  * when a project is scheduled
  * Will cause a unique build for each different node if a job is already queued.
- * 
+ *
  * @author Chris Johnson
  */
 public class NodeAction extends InvisibleAction implements LabelAssignmentAction, Queue.QueueAction, BuildBadgeAction {
 	private final Label nodeLabel;
-	
+
 	public NodeAction(Label nodeLabel) {
 		this.nodeLabel = nodeLabel;
 	}
 
 	public Label getAssignedLabel(SubTask task) {
-		return nodeLabel;
+		if (nodeLabel != null) {
+			// Ensure that we are returning the canonical Label for this expression,
+			// according to the Jenkins instance.
+			return Label.get(nodeLabel.getName());
+		} else {
+			return nodeLabel;
+		}
 	}
-	
+
 	public boolean shouldSchedule(List<Action> actions) {
 		// see if there is already a matching action with same node
 		for (NodeAction other:Util.filter(actions, NodeAction.class)) {


### PR DESCRIPTION
### SUMMARY

Proposed fix for https://issues.jenkins-ci.org/browse/JENKINS-57507.

### DETAILS

If the parameterized trigger plugin triggers a build, using a `NodeAction` to refer to a specific label or machine (self-label), it attaches the NodeAction directly to a Label object.

Normally this is fine, but if the machine disconnects at the wrong moment, you can end up with an "orphaned label".  It becomes orphaned because Jenkins periodically cleans up Labels that have no connected nodes, and then recreates a new one for the node when it reconnects.  When this happens, if you retain a reference to the individual Label object, that Label will never see any newly connected nodes.

The fix is for the `getAssignedLabel` method to always return the "canonical" label for for the given label expression, by asking the Jenkins instance for it, rather than returning our (potentially stale) Label reference.

