### PR TITLE
Avoid array index  out of bound

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -121,12 +121,10 @@ public class BuildTrigger extends Notifier implements DependencyDeclarer {
 					String[] projects = config.getProjects(build.getEnvironment(listener)).split(",");
 					String[] vars = config.getProjects().split(",");
 					for (int i = 0; i < projects.length; i++) {
-						if (vars[i].trim().contains("$")) {
-							AbstractBuild abstractBuild = downstreamMap.get(projects[i]);
-							if (null != abstractBuild) {
-								listener.getLogger().println(makeLogEntry(projects[i].trim()));
-								buildMap.put(abstractBuild.getProject().getFullName(), abstractBuild.getNumber());
-							}
+						AbstractBuild abstractBuild = downstreamMap.get(projects[i]);
+						if (null != abstractBuild) {
+							listener.getLogger().println(makeLogEntry(projects[i].trim()));
+							buildMap.put(abstractBuild.getProject().getFullName(), abstractBuild.getNumber());
 						}
 					}
 


### PR DESCRIPTION
I have a project that use variables to trigger parameterized build. 
I.e.g Instead of using job name, it is $jobs where jobs=job1,job2,job3
In this case, the existing code throws array index out of bound exception. 
Any reason code is iterating projects array and test vars[i]?
Also I don't think testing vars[i].trim().contains("$") is needed
