### PR TITLE
Don't automatically mark the parent job as SUCCESS

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockingBehaviour.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockingBehaviour.java
@@ -86,7 +86,7 @@ public class BlockingBehaviour extends AbstractDescribableImpl<BlockingBehaviour
     public Result mapBuildResult(Result r) {
         if (failureThreshold!=null && r.isWorseOrEqualTo(failureThreshold))   return FAILURE;
         if (unstableThreshold!=null && r.isWorseOrEqualTo(unstableThreshold))  return UNSTABLE;
-        return SUCCESS;
+        return null;
     }
 
     @Extension


### PR DESCRIPTION
When this plugin is used to call another job during the build or pre-scm build stages, and the user chooses to block on the job until it's completed, this plugin sets the parent job status to "SUCCESS", even though there should be no assumption that the success of the child job mandates success of the parent job.

Example:

1. Job A -> enables "Run buildstep before SCM runs" and adds a "Trigger/call builds on other projects" step, to call Job B
2. Job B completes successfully.
3. The parameterized trigger plugin sets the result of Job A to "SUCCESS" even though nothing that's happened so far indicates that Job A is "SUCCESS".

This can cause strange issues in a few cases; for example, the extended e-mail notifier plugin can send e-mails at various stages, including "immediately before the build starts". We have an e-mail template that goes out to developers, and we include ${BUILD_STATUS} in the template, but because of this behaviour in this plugin, the "Your build has started" e-mail tells them that the build is a success; when they go to view the job, it's not finished, and they're left wondering why they got an e-mail saying success when it's not successful.

While the user can customize marking the build as failed, as a failure, or as unstable, there's no option for the user to choose to mark the current build as success; furthermore, I don't think that marking the build as a success so early in the build process necessarily makes sense, but I could be mistaken.