### PR TITLE
Add a definition of the term "Subprojects" that appears in Jenkins UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Parameterized Trigger Plugin
 This plugin lets you trigger new builds when your build has completed,
 with various ways of specifying parameters for the new build.
 
-  
+These new builds appear as "Subprojects" in the Jenkins UI when you
+are looking at a project that triggers them.
+
 You can add multiple configurations: each has a list of projects to trigger, a condition for when to trigger them 
 (based on the result of the current build), and a parameters section.
 


### PR DESCRIPTION
See
https://github.com/jenkins-infra/jenkins.io/issues/3948#issuecomment-724514107
for the background on this pull request; in short, I saw "Subprojects"
in a Jenkins UI and didn't know what it meant. It would be nice if this
was defined in the README for the plugin that adds that UI element. :)