### PR TITLE
More logging for BuildTriggerTest.testParentProjectTrigger

### DIFF
--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerTest.java
@@ -17,6 +17,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Run;
 import hudson.model.StringParameterDefinition;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BuildTrigger;
@@ -34,7 +35,9 @@ import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import hudson.tasks.Builder;
+import java.util.logging.Level;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
 
 /**
  *
@@ -44,6 +47,9 @@ public class BuildTriggerTest {
     
     @Rule
     public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logging = new LoggerRule().record(Run.class, Level.FINE);
     
     @Test
     public void testParentProjectTrigger() throws Exception{


### PR DESCRIPTION
Saw a `plugin-compat-tester` failure

```
java.lang.AssertionError: Downstream job should be triggered
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertNotNull(Assert.java:713)
	at hudson.plugins.parameterizedtrigger.test.BuildTriggerTest.testParentProjectTrigger(BuildTriggerTest.java:65)
```

Guessing this was a race condition but hard to know since there are no log messages while the test runs:

```
…
0.793 [id=…]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
4.662 [id=…]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
…
```

This patch helps some, though if https://github.com/jenkinsci/jenkins/pull/4345#discussion_r348496722 had been accepted it would have helped more.
