### PR TITLE
Adapt the plugin to be compatable with future versions of Guava

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BinaryFileParameterFactory.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BinaryFileParameterFactory.java
@@ -1,6 +1,5 @@
 package hudson.plugins.parameterizedtrigger;
 
-import com.google.common.collect.Lists;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
@@ -15,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -53,7 +53,7 @@ public class BinaryFileParameterFactory extends AbstractBuildParameterFactory {
 
     @Override
     public List<AbstractBuildParameters> getParameters(AbstractBuild<?, ?> build, TaskListener listener) throws IOException, InterruptedException, AbstractBuildParameters.DontTriggerException {
-        List<AbstractBuildParameters> result = Lists.newArrayList();
+        List<AbstractBuildParameters> result = new ArrayList<>();
         FilePath workspace = build.getWorkspace();
         if (workspace == null) {
             throw new IOException("Failed to get workspace");

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BlockableBuildTriggerConfig.java
@@ -1,6 +1,5 @@
 package hudson.plugins.parameterizedtrigger;
 
-import com.google.common.collect.ImmutableList;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -18,6 +17,7 @@ import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -72,8 +72,9 @@ public class BlockableBuildTriggerConfig extends BuildTriggerConfig {
             while (true) {
                 // add DifferentiatingAction to make sure this doesn't get merged with something else,
                 // which is most likely unintended. Might make sense to do it at BuildTriggerConfig for all.
-                list = ImmutableList.<Action>builder().addAll(list).add(new DifferentiatingAction()).build();
+                list = CollectionUtils.immutableList(list, new DifferentiatingAction());
 
+                
                 // if we fail to add the item to the queue, wait and retry.
                 // it also means we have to force quiet period = 0, or else it'll never leave the queue
                 QueueTaskFuture f = schedule(build, project, 0, list, listener);

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTrigger.java
@@ -1,6 +1,5 @@
 package hudson.plugins.parameterizedtrigger;
 
-import com.google.common.collect.ImmutableList;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -27,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -62,7 +62,7 @@ public class BuildTrigger extends Notifier implements DependencyDeclarer {
 
 	@Override
 	public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
-		return ImmutableList.of(new DynamicProjectAction(configs));
+		return Collections.singletonList(new DynamicProjectAction(configs));
 	}
 
 	@Override @SuppressWarnings("deprecation")

--- a/src/main/java/hudson/plugins/parameterizedtrigger/CollectionUtils.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/CollectionUtils.java
@@ -1,0 +1,29 @@
+package hudson.plugins.parameterizedtrigger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Internal helpers that should be replaced by Java11 equivalents when the JDK baseline moves on.
+ *
+ */
+@Restricted(NoExternalUse.class)
+final class CollectionUtils {
+
+    static <T> List<T> immutableList(Collection<T> collection1, Collection<T> collection2) {
+        List<T> list = new ArrayList<>(collection1);
+        list.addAll(collection2);
+        return Collections.unmodifiableList(list);
+    }
+
+    static <T> List<T> immutableList(Collection<T> collection, @SuppressWarnings("unchecked") T... ts) {
+        List<T> list = new ArrayList<>(collection);
+        list.addAll(Arrays.asList(ts));
+        return Collections.unmodifiableList(list);
+    }
+}

--- a/src/main/java/hudson/plugins/parameterizedtrigger/CounterBuildParameterFactory.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/CounterBuildParameterFactory.java
@@ -1,6 +1,5 @@
 package hudson.plugins.parameterizedtrigger;
 
-import com.google.common.collect.ImmutableMap;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Util;
@@ -14,6 +13,7 @@ import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -107,7 +107,7 @@ public class CounterBuildParameterFactory extends AbstractBuildParameterFactory 
     }
 
     private PredefinedBuildParameters getParameterForCount(Long i) {
-        String stringWithCount = Util.replaceMacro(paramExpr, ImmutableMap.of("COUNT", i.toString()));
+        String stringWithCount = Util.replaceMacro(paramExpr, Collections.singletonMap("COUNT", i.toString()));
         return new PredefinedBuildParameters(stringWithCount);
     }
 

--- a/src/main/java/hudson/plugins/parameterizedtrigger/SubProjectsAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/SubProjectsAction.java
@@ -1,9 +1,8 @@
 package hudson.plugins.parameterizedtrigger;
 
-import com.google.common.collect.ImmutableList;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
-
+import java.util.Collections;
 import java.util.List;
 /**
  * Action added Projects to track what projects are
@@ -47,7 +46,7 @@ public class SubProjectsAction implements Action {
         if (isFirst()) {
             return project.getActions(SubProjectsAction.class);
         }
-        return ImmutableList.of();
+        return Collections.emptyList();
     }
 
     public AbstractProject<?,?> getProject() {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -25,7 +25,6 @@
 
 package hudson.plugins.parameterizedtrigger;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import hudson.*;
 import hudson.console.HyperlinkNote;
@@ -199,7 +198,7 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
 
     @Override
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
-        return ImmutableList.of(new SubProjectsAction(project, configs));
+        return Collections.singletonList(new SubProjectsAction(project, configs));
     }
 
     private boolean canDeclare(AbstractProject owner) {

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest.java
@@ -23,8 +23,6 @@
  */
 package hudson.plugins.parameterizedtrigger.test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause.UserIdCause;
@@ -33,7 +31,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Project;
 import hudson.model.Result;
 import hudson.model.Run;
-import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.BlockingBehaviour;
@@ -48,6 +45,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
@@ -57,6 +56,7 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -65,6 +65,8 @@ public class BuildInfoExporterTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
+    
+    @Rule public BuildWatcher buildWatcher = new BuildWatcher();
 
     @Test
     public void test() throws Exception {
@@ -175,7 +177,7 @@ public class BuildInfoExporterTest {
                 new TriggerBuilder(
                 new BlockableBuildTriggerConfig(testNameResult + "," + testNameResult2,
                 new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
-                ImmutableList.of(new CounterBuildParameterFactory("0", Integer.toString(buildsToTest - 1), "1", "TEST=COUNT$COUNT")),
+                Arrays.asList(new CounterBuildParameterFactory("0", Integer.toString(buildsToTest - 1), "1", "TEST=COUNT$COUNT")),
                 Collections.emptyList())));
 
         CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
@@ -353,14 +355,12 @@ public class BuildInfoExporterTest {
           //  downstream1#2
           //  downstream2#1
 
-          assertEquals(
-              Sets.newHashSet(
-                      r.jenkins.getItemByFullName("downstream1", FreeStyleProject.class).getBuildByNumber(1),
+          Set<Run<?,?>> expected = new HashSet<>();
+          expected.addAll(Arrays.asList(r.jenkins.getItemByFullName("downstream1", FreeStyleProject.class).getBuildByNumber(1),
                       r.jenkins.getItemByFullName("downstream1", FreeStyleProject.class).getBuildByNumber(2),
-                      r.jenkins.getItemByFullName("downstream2", FreeStyleProject.class).getBuildByNumber(1)
-              ),
-              new HashSet<AbstractBuild<?,?>>(action.getTriggeredBuilds())
-          );
+                      r.jenkins.getItemByFullName("downstream2", FreeStyleProject.class).getBuildByNumber(1)));
+          
+          assertEquals(expected, new HashSet<>(action.getTriggeredBuilds()));
 
           EnvVars env = new EnvVars();
           action.buildEnvVars(b, env);
@@ -383,13 +383,12 @@ public class BuildInfoExporterTest {
           //  downstream1#2
           //  downstream2#1
 
-          assertEquals(
-              Sets.newHashSet(
-                      r.jenkins.getItemByFullName("downstream1", FreeStyleProject.class).getBuildByNumber(1),
+          Set<Run<?,?>> expected = new HashSet<>();
+          expected.addAll(Arrays.asList(r.jenkins.getItemByFullName("downstream1", FreeStyleProject.class).getBuildByNumber(1),
                       r.jenkins.getItemByFullName("downstream1", FreeStyleProject.class).getBuildByNumber(2),
-                      r.jenkins.getItemByFullName("downstream2", FreeStyleProject.class).getBuildByNumber(1)
-              ),
-              new HashSet<AbstractBuild<?,?>>(action.getTriggeredBuilds())
+                      r.jenkins.getItemByFullName("downstream2", FreeStyleProject.class).getBuildByNumber(1)));
+
+          assertEquals(expected, new HashSet<>(action.getTriggeredBuilds())
           );
 
           EnvVars env = new EnvVars();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerConfigTest.java
@@ -54,6 +54,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -80,6 +81,9 @@ public class BuildTriggerConfigTest {
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
+    
+    @Rule
+    public BuildWatcher buildWatcher = new BuildWatcher();
 
     private BlockableBuildTriggerConfig createConfig(String projectToTrigger){
         List<AbstractBuildParameters> buildParameters = new ArrayList<AbstractBuildParameters>();

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerTest.java
@@ -1,6 +1,5 @@
 package hudson.plugins.parameterizedtrigger.test;
 
-import com.google.common.collect.Lists;
 import hudson.AbortException;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -110,7 +109,7 @@ public class BuildTriggerTest {
 
         String project1 = downstreamBuild1.getCause(Cause.UpstreamCause.class).getUpstreamProject();
         String project2 = downstreamBuild2.getCause(Cause.UpstreamCause.class).getUpstreamProject();
-        ArrayList<MatrixConfiguration> configurations = Lists.newArrayList(upstream.getItems());
+        ArrayList<MatrixConfiguration> configurations = new ArrayList<>(upstream.getItems());
         Collections.sort(configurations, new MatrixConfigurationSorterTestImpl());
         assertEquals("Build should be triggered by matrix project.", configurations.get(0).getFullName(), project1);
         assertEquals("Build should be triggered by matrix project.", configurations.get(1).getFullName(), project2);

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CaptureAllEnvironmentBuilder.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CaptureAllEnvironmentBuilder.java
@@ -1,6 +1,5 @@
 package hudson.plugins.parameterizedtrigger.test;
 
-import com.google.common.collect.Maps;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
@@ -12,13 +11,14 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * @author wolfs
  */
 public class CaptureAllEnvironmentBuilder extends Builder {
-    private final Map<String,EnvVars> envVars = Maps.newHashMap();
+    private final Map<String,EnvVars> envVars = new HashMap<>();
 
 	public Map<String, EnvVars> getEnvVars() {
 		return envVars;

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/CounterBuildParameterFactoryTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/CounterBuildParameterFactoryTest.java
@@ -1,8 +1,5 @@
 package hudson.plugins.parameterizedtrigger.test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import hudson.EnvVars;
 import hudson.model.Cause.UserIdCause;
 import hudson.model.FreeStyleBuild;
@@ -11,7 +8,6 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Project;
 import hudson.model.StringParameterDefinition;
 import hudson.model.Result;
-import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.BlockingBehaviour;
@@ -23,7 +19,9 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -43,7 +41,7 @@ public class CounterBuildParameterFactoryTest {
                 new TriggerBuilder(
                         new BlockableBuildTriggerConfig(projectB.getName(),
                                 new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
-                                ImmutableList.<AbstractBuildParameterFactory>of(new CounterBuildParameterFactory("0","1","1", "TEST=COUNT$COUNT")),
+                                Collections.singletonList(new CounterBuildParameterFactory("0","1","1", "TEST=COUNT$COUNT")),
                                 Collections.<AbstractBuildParameters>emptyList())));
 
         CaptureAllEnvironmentBuilder builder = new CaptureAllEnvironmentBuilder();
@@ -59,13 +57,13 @@ public class CounterBuildParameterFactoryTest {
         r.waitUntilNoActivity();
         List<FreeStyleBuild> builds = projectB.getBuilds();
         assertEquals(2, builds.size());
-        Set<String> values = Sets.newHashSet();
+        Set<String> values = new HashSet<>();
         for (FreeStyleBuild build : builds) {
             EnvVars buildEnvVar = builder.getEnvVars().get(build.getId());
             assertTrue(buildEnvVar.containsKey("TEST"));
             values.add(buildEnvVar.get("TEST"));
         }
-        assertEquals(ImmutableSet.of("COUNT0","COUNT1"), values);
+        assertEquals(new HashSet<>(Arrays.asList("COUNT0","COUNT1")), values);
     }
 
     @Test
@@ -76,7 +74,7 @@ public class CounterBuildParameterFactoryTest {
                 new TriggerBuilder(
                         new BlockableBuildTriggerConfig(projectB.getName(),
                                 new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
-                                ImmutableList.<AbstractBuildParameterFactory>of(
+                                Arrays.asList(
                                         new CounterBuildParameterFactory("0","1","1", "TEST=COUNT$COUNT"),
                                         new CounterBuildParameterFactory("0","2","1", "NEWTEST=COUNT$COUNT")
                                         ),
@@ -97,8 +95,8 @@ public class CounterBuildParameterFactoryTest {
         r.waitUntilNoActivity();
         List<FreeStyleBuild> builds = projectB.getBuilds();
         assertEquals(6, builds.size());
-        Set<String> values = Sets.newHashSet();
-        Set<String> newValues = Sets.newHashSet();
+        Set<String> values = new HashSet<>();
+        Set<String> newValues = new HashSet<>();
         for (FreeStyleBuild build : builds) {
             EnvVars buildEnvVar = builder.getEnvVars().get(build.getId());
             assertTrue(buildEnvVar.containsKey("TEST"));
@@ -106,8 +104,8 @@ public class CounterBuildParameterFactoryTest {
             values.add(buildEnvVar.get("TEST"));
             newValues.add(buildEnvVar.get("NEWTEST"));
         }
-        assertEquals(ImmutableSet.of("COUNT0","COUNT1"), values);
-        assertEquals(ImmutableSet.of("COUNT0", "COUNT1", "COUNT2"), newValues);
+        assertEquals(new HashSet<>(Arrays.asList("COUNT0","COUNT1")), values);
+        assertEquals(new HashSet<>(Arrays.asList("COUNT0", "COUNT1", "COUNT2")), newValues);
     }
 
 }

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildParameterFactoryTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/FileBuildParameterFactoryTest.java
@@ -23,10 +23,6 @@
  */
 package hudson.plugins.parameterizedtrigger.test;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -55,7 +51,9 @@ import org.junit.Test;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.io.IOException;
@@ -78,8 +76,7 @@ public class FileBuildParameterFactoryTest {
         TriggerBuilder tBuilder = new TriggerBuilder(
                                 new BlockableBuildTriggerConfig(project.getName(),
                                 new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
-                                ImmutableList.<AbstractBuildParameterFactory>of(
-                                    new FileBuildParameterFactory("*.txt", encoding, action)),
+                                Arrays.asList(new FileBuildParameterFactory("*.txt", encoding, action)),
                                 Collections.<AbstractBuildParameters>emptyList()));
         return tBuilder;
     }
@@ -116,13 +113,13 @@ public class FileBuildParameterFactoryTest {
         List<FreeStyleBuild> builds = projectB.getBuilds();
         assertEquals(1, builds.size());
 
-        Set<String> values = Sets.newHashSet();
+        Set<String> values = new HashSet<>();
         for (FreeStyleBuild build : builds) {
             EnvVars buildEnvVar = builder.getEnvVars().get(build.getId());
             assertTrue(buildEnvVar.containsKey("TEST"));
             values.add(buildEnvVar.get("TEST"));
         }
-        assertEquals(ImmutableSet.of("hello_abc"), values);
+        assertEquals(Collections.singleton("hello_abc"), values);
 
     }
 
@@ -159,13 +156,13 @@ public class FileBuildParameterFactoryTest {
         List<FreeStyleBuild> builds = projectB.getBuilds();
         assertEquals(2, builds.size());
 
-        Set<String> values = Sets.newHashSet();
+        Set<String> values = new HashSet<>();
         for (FreeStyleBuild build : builds) {
             EnvVars buildEnvVar = builder.getEnvVars().get(build.getId());
             assertTrue(buildEnvVar.containsKey("TEST"));
             values.add(buildEnvVar.get("TEST"));
         }
-        assertEquals(ImmutableSet.of("hello_abc","hello_xyz"), values);
+        assertEquals(new HashSet<>(Arrays.asList("hello_abc","hello_xyz")), values);
 
     }
 

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
@@ -59,8 +59,6 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.io.IOException;
 
-import com.google.common.collect.ImmutableList;
-
 import java.lang.System;
 
 import jenkins.model.Jenkins;
@@ -235,7 +233,7 @@ public class TriggerBuilderTest {
         Project<?,?> triggerProject = r.createFreeStyleProject();
 
         BlockingBehaviour blockingBehaviour = new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE);
-        ImmutableList<AbstractBuildParameterFactory> buildParameter = ImmutableList.<AbstractBuildParameterFactory>of(new CounterBuildParameterFactory("0", "2", "1", "TEST=COUNT$COUNT"));
+        List<AbstractBuildParameterFactory> buildParameter = Collections.singletonList(new CounterBuildParameterFactory("0", "2", "1", "TEST=COUNT$COUNT"));
         List<AbstractBuildParameters> emptyList = Collections.emptyList();
 
         BlockableBuildTriggerConfig bBTConfig = new BlockableBuildTriggerConfig("project1, project2, project3", blockingBehaviour, buildParameter, emptyList);


### PR DESCRIPTION
mostly by replacing all guava occurences with non guava as it is not
needed at all.
However the Multimap usage remains as there is no corresponding
equivallent and this API is not going to change between guava 11 and
guava 31.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
