### PR TITLE
Fix flakiness in BuildTriggerTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,18 @@
       <artifactId>token-macro</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.1.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
There was the possibility of a race condition where the queue was empty but the downstream job not yet added to it, resulting in assertions about the downstream being checked too early and fail.

Show in a CI run under heavy load, not something usual, but this change should remove the possibility

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
