### PR TITLE
Use https instead of git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
   </dependencyManagement>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -221,4 +221,3 @@
     <spotbugs.failOnError>false</spotbugs.failOnError>
   </properties>
 </project>
-


### PR DESCRIPTION
Use https protocol instead of git protocol because GitHub is deprecating git protocol

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did