### PR TITLE
`conditional-buildstep` dep should be optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>conditional-buildstep</artifactId>
       <version>1.4.1</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- Workflow plugin imports are used to test compatibility -->


### PR DESCRIPTION
Especially because it pulls in a hard dep on `maven-plugin`! (https://github.com/jenkinsci/conditional-buildstep-plugin/pull/27)

Was done correctly in #42 but regressed in #100.
