### PR TITLE
Suppress spotbugs errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,5 +230,6 @@
     <java.level>8</java.level>
     <jenkins.version>2.332.1</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
+    <spotbugs.configuration.excludeFilterFile>suppressed-spotbug-errors.xml</spotbugs.configuration.excludeFilterFile>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,6 @@
     <java.level>8</java.level>
     <jenkins.version>2.332.1</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
-    <spotbugs.configuration.excludeFilterFile>suppressed-spotbug-errors.xml</spotbugs.configuration.excludeFilterFile>
+    <spotbugs.excludeFilterFile>suppressed-spotbug-errors.xml</spotbugs.excludeFilterFile>
   </properties>
 </project>

--- a/suppressed-spotbug-errors.xml
+++ b/suppressed-spotbug-errors.xml
@@ -5,7 +5,35 @@
     for an explanation of the technique
  -->
 <FindBugsFilter>
-    <Match>
+    <!-- <Match>
         <Source name="~.*BlockableBuildTriggerConfig\.java"/>
-    </Match>
+    </Match> -->
+    <Match>
+    <Or>
+        <And>
+            <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+            <Class name="hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig"/>
+        </And>
+        <And>
+            <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"/>
+            <Class name="hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig"/>
+        </And>
+        <And>
+            <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS"/>
+            <Class name="hudson.plugins.parameterizedtrigger.Plugin"/>
+      </And>
+        <And>
+            <Bug pattern="UUF_UNUSED_FIELD"/>
+            <Class name="hudson.plugins.parameterizedtrigger.FileBuildTriggerConfig"/>
+      </And>
+        <And>
+            <Bug pattern="UUF_UNUSED_FIELD"/>
+            <Class name="hudson.plugins.parameterizedtrigger.PredefinedPropertiesBuildTriggerConfig"/>
+      </And>
+        <And>
+            <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+            <Class name="hudson.plugins.parameterizedtrigger.NodeParameters"/>
+      </And>
+    </Or>
+  </Match>
 </FindBugsFilter>

--- a/suppressed-spotbug-errors.xml
+++ b/suppressed-spotbug-errors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+    see https://spotbugs.readthedocs.io/en/stable/filter.html#source
+    and https://stackoverflow.com/questions/52336795/spotbugs-maven-plugin-exclude-a-directory
+    for an explanation of the technique
+ -->
+<FindBugsFilter>
+    <Match>
+        <Source name="~.*BlockableBuildTriggerConfig\.java"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
This plugin will be used the DW2022 Contributing Workshop. In order to keep the focus of trainees, I propose to suppress the spotbugs errors. The compile will not have impressive warnings and the CI job has more chances to run successfully.

Suppressed warnings are stored in the suppressed-spotbug-errors.xml file

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
