### PR TITLE
[WIP] JENKINS-64591 Matrix Job - Trigger downstream Workflow job for all childs only when configured

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ListMultimap;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.matrix.MatrixRun;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
@@ -529,6 +530,10 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
 
                 return new UpstreamCause((Run<?,?>)promotion.getTargetBuild());
             }
+        }
+        if(build instanceof MatrixRun && ! triggerFromChildProjects) {
+            MatrixRun matrixRun = (MatrixRun)build;
+            return new UpstreamCause((Run<?,?>)matrixRun.getParentBuild());
         }
         return new UpstreamCause(build);
     }

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/BuildTriggerTest.java
@@ -30,6 +30,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import static org.junit.Assert.*;
 
@@ -37,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import hudson.tasks.Builder;
 import java.util.logging.Level;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 
@@ -79,8 +82,41 @@ public class BuildTriggerTest {
 
         String project = downstream.getLastBuild().getCause(Cause.UpstreamCause.class).getUpstreamProject();
         assertEquals("Build should be triggered by matrix project.", "upstream", project);
+        assertEquals("Downstream should be triggered once by matrix project parent.", 1, downstream.getLastBuild().number);
     }
-    
+
+    @Issue("JENKINS-64591")
+    @Test
+    public void testParentProjectTriggerPipeline() throws Exception {
+        MatrixProject upstream = r.createProject(MatrixProject.class, "upstream");
+        WorkflowJob downstream = r.createProject(WorkflowJob.class, "downstream");
+
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("parameter","parameter-value"));
+        upstream.addProperty(new ParametersDefinitionProperty(definition));
+        AxisList axes = new AxisList();
+        axes.add(new TextAxis("textAxis","one","two"));
+        upstream.setAxes(axes);
+        List<AbstractBuildParameters> params = new ArrayList<AbstractBuildParameters>();
+        params.add(new CurrentBuildParameters());
+        BuildTrigger triggerBuilder = new BuildTrigger(new BuildTriggerConfig("downstream", ResultCondition.SUCCESS, false, null, params, false));
+        upstream.getPublishersList().add(triggerBuilder);
+
+        /*
+         * To avoid a period when upstream already finished, but async rebuilding graph {@link Jenkins#rebuildDependencyGraphAsync()}
+         * could still be in progress or even not start.
+         * Let's rebuild graph manually just in case to avoid flakiness.
+         */
+        r.jenkins.rebuildDependencyGraph();
+
+        r.buildAndAssertSuccess(upstream);
+        r.waitUntilNoActivity();
+
+        String project = downstream.getLastBuild().getCause(Cause.UpstreamCause.class).getUpstreamProject();
+        assertEquals("Build should be triggered by matrix project.", "upstream", project);
+        assertEquals("Downstream should be triggered once by matrix project parent.", 1, downstream.getLastBuild().number);
+    }
+
     @Test
     public void testChildProjectsTrigger() throws Exception {
         MatrixProject upstream = r.createProject(MatrixProject.class, "upstream");
@@ -114,7 +150,9 @@ public class BuildTriggerTest {
         FreeStyleBuild downstreamBuild2 = downstream.getLastBuild();
         FreeStyleBuild downstreamBuild1 = downstreamBuild2.getPreviousBuild();
         assertNotNull("Downstream job should be triggered by matrix configuration", downstreamBuild1);
+        assertEquals("Downstream should be triggered twice by matrix project.", 1, downstreamBuild1.number);
         assertNotNull("Downstream job should be triggered by matrix configuration", downstreamBuild2);
+        assertEquals("Downstream should be triggered twice by matrix project", 2, downstreamBuild2.number);
 
         String project1 = downstreamBuild1.getCause(Cause.UpstreamCause.class).getUpstreamProject();
         String project2 = downstreamBuild2.getCause(Cause.UpstreamCause.class).getUpstreamProject();
@@ -123,7 +161,53 @@ public class BuildTriggerTest {
         assertEquals("Build should be triggered by matrix project.", configurations.get(0).getFullName(), project1);
         assertEquals("Build should be triggered by matrix project.", configurations.get(1).getFullName(), project2);
     }
-    
+
+    @Issue("JENKINS-64591")
+    @Test
+    public void testChildProjectsTriggerPipeline() throws Exception {
+        MatrixProject upstream = r.createProject(MatrixProject.class, "upstream");
+        WorkflowJob downstream = r.createProject(WorkflowJob.class, "downstream");
+
+        List<ParameterDefinition> definition = new ArrayList<ParameterDefinition>();
+        definition.add(new StringParameterDefinition("parameter","parameter-value"));
+        ParametersDefinitionProperty property = new ParametersDefinitionProperty(definition);
+        upstream.addProperty(property);
+        
+        AxisList axes = new AxisList();
+        axes.add(new TextAxis("textAxis","a","b"));
+        upstream.setAxes(axes);
+        upstream.getBuildersList().add(new CreatePropertyFileBuilder());
+        DefaultMatrixExecutionStrategyImpl strategy = new DefaultMatrixExecutionStrategyImpl(true, null, null, null);
+        upstream.setExecutionStrategy(strategy);
+        
+        List<AbstractBuildParameters> params = new ArrayList<AbstractBuildParameters>();
+        params.add(new CurrentBuildParameters());
+        List<AbstractBuildParameters> parameters = new ArrayList<AbstractBuildParameters>();
+        parameters.add(new FileBuildParameters("property.prop", null, false, true, null, false));
+        BuildTriggerConfig config = new BuildTriggerConfig("downstream", ResultCondition.SUCCESS, false, parameters, true);
+        BuildTrigger triggerBuilder = new BuildTrigger(config);
+        upstream.getPublishersList().add(triggerBuilder);
+        r.jenkins.rebuildDependencyGraph();
+        strategy.setSorter(new MatrixConfigurationSorterTestImpl());
+        
+        r.buildAndAssertSuccess(upstream);
+        r.waitUntilNoActivity();
+        
+        WorkflowRun downstreamBuild2 = downstream.getLastBuild();
+        WorkflowRun downstreamBuild1 = downstreamBuild2.getPreviousBuild();
+        assertNotNull("Downstream job should be triggered by matrix configuration", downstreamBuild1);
+        assertEquals("Downstream should be triggered twice by matrix project.", 1, downstreamBuild1.number);
+        assertNotNull("Downstream job should be triggered by matrix configuration", downstreamBuild2);
+        assertEquals("Downstream should be triggered twice by matrix project", 2, downstreamBuild2.number);
+
+        String project1 = downstreamBuild1.getCause(Cause.UpstreamCause.class).getUpstreamProject();
+        String project2 = downstreamBuild2.getCause(Cause.UpstreamCause.class).getUpstreamProject();
+        ArrayList<MatrixConfiguration> configurations = new ArrayList<>(upstream.getItems());
+        Collections.sort(configurations, new MatrixConfigurationSorterTestImpl());
+        assertEquals("Build should be triggered by matrix project.", configurations.get(0).getFullName(), project1);
+        assertEquals("Build should be triggered by matrix project.", configurations.get(1).getFullName(), project2);
+    }
+
     public static class MatrixConfigurationSorterTestImpl extends MatrixConfigurationSorter implements Serializable {
 
         @Override


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira: https://issues.jenkins.io/browse/JENKINS-64591
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

This issue only arises for Matrix Job.
When configuring a downstream job (post-build step), not enabling the option `Trigger build from child projects`, it is expected that only one run of the downstream job will be executed.
Turns out it is right for FreeStyle downstream job, but wrong for Workflow downstream job.

For a Matrix Job, it seems the downstream jobs will get triggered by 2 different mechanisms:
* dependency graph in case of FreeStyleJob
* direct call in case of Workflow job

Root cause of the issue is the UpstreamCause object is not created in the same "project level" context.
So in [constructor](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Cause.java#L180-L181) some calls will return different values:
* For FreeStyleJob, Matrix Parent job name (ie. upstream_job) and url
* For Workflow job, Matrix Parent configuration job name (ie. upstream_job/axis1=test) and url

Result is:
* For FreeStyleJob, all causes are considered "equals", so only one downstream job is started
* For Workflow job, each cause is considered unique (see [UpstreamCause.equals()](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Cause.java#L214-L226) implementation)

Proposed fix is to handle the case `build instanceof MatrixRun && ! triggerFromChildProjects` when creating the UpstreamCause, and in such case use the parentBuild() of the MatrixRun, so its name won't have the matrix configuration added (/axis1=test)

I have added 2 test cases to illustrate this behavior.

Sadly, it is breaking other tests from `FileBuildTriggerConfigTest`, and i am not sure how to fix this yet... Any help appreciated