### PR TITLE
Disable Java 17 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(useAci: true, configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
         [ platform: "linux", jdk: "8" ],
         [ platform: "windows", jdk: "8" ],
         [ platform: "linux", jdk: "11" , jenkins: '2.361.2'] , 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 buildPlugin(useContainerAgent: true, configurations: [
         [ platform: 'linux', jdk: '8' ],
         [ platform: 'windows', jdk: '8' ],
-        [ platform: 'linux', jdk: '11' , jenkins: '2.361.2'] , 
-        [platform: 'linux',   jdk: '17', jenkins: '2.375']
+        [ platform: 'linux', jdk: '11' , jenkins: '2.361.2'], 
+        // [ platform: 'linux',   jdk: '17', jenkins: '2.375']
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, configurations: [
-        [ platform: "linux", jdk: "8" ],
-        [ platform: "windows", jdk: "8" ],
-        [ platform: "linux", jdk: "11" , jenkins: '2.361.2'] , 
+        [ platform: 'linux', jdk: '8' ],
+        [ platform: 'windows', jdk: '8' ],
+        [ platform: 'linux', jdk: '11' , jenkins: '2.361.2'] , 
         [platform: 'linux',   jdk: '17', jenkins: '2.375']
 ])


### PR DESCRIPTION
## Disable Java 17 in CI

- Use useContainerAgent instead of useAci in Jenkinsfile
- Use single quoted strings in Jenkinsfile
- Do not test JDK 17 in CI

Java 17 fails tests because it is attempting to serialize mockito objects in a way that Java 17 appears to not allow.  Needs fixes before Java 17 is enabled in CI.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
