### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,12 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(
+  // Run a JVM per core in tests
+  forkCount: '1C',
+  // Container agents start faster and are easier to administer
   useContainerAgent: true,
+  // Test Java 11, 17, and 21
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21, jenkins: '2.414'],
     [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
## Test with Java 21

We'd like to support Java 21 soon after its Sep 19, 2023 release.  Testing plugins with Java 21 early access helps towards that goal.

### Testing done

Confirmed tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
