### PR TITLE
JENKINS-71919 Use modern icon class in subproject page

### DIFF
--- a/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
+++ b/src/main/resources/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction/summary.groovy
@@ -6,6 +6,8 @@ if (System.getProperty(DISABLE_ACTION_VIEWS_KEY) != null) {
 	return
 }
 
+def l = namespace(lib.LayoutTagLib)
+
 def builds = my.triggeredBuilds
 if(builds.size() > 0) {
 	h2("Subproject Builds")
@@ -18,8 +20,7 @@ if(builds.size() > 0) {
 						text(item.project.displayName)
 					}
 					a(href:"${rootURL}/${item.url}", class:"model-link") {
-						img(src:"${imagesURL}/16x16/${item.buildStatusUrl}",
-								alt:"${item.iconColor.description}", height:"16", width:"16")
+						l.icon(class: "${item.iconColor.iconClassName} icon-sm", alt:"${item.iconColor.description}")
 						text(item.displayName)
 					}
 				}


### PR DESCRIPTION
This PR fixes https://issues.jenkins.io/browse/JENKINS-71919

### Testing done

`mvn -ntp clean verify` maven command is successful

#### Before
![before](https://github.com/jenkinsci/parameterized-trigger-plugin/assets/47566129/2005a717-67ce-4553-86b1-94acdd46a222)

#### After
![after](https://github.com/jenkinsci/parameterized-trigger-plugin/assets/47566129/8babff4c-c044-4fe3-8445-ef410cb09653)

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```