### PR TITLE
Cancel pending triggered build when parent project is cancelled

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -148,7 +148,15 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
                             try {
                                 if (future != null ) {
                                     listener.getLogger().println("Waiting for the completion of " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()));
-                                    Run startedRun = future.waitForStart();
+                                    Run startedRun;
+                                    try {
+                                        startedRun = future.waitForStart();
+                                    } catch (InterruptedException x) {
+                                        listener.getLogger().println( "Build aborting: cancelling queued project " + HyperlinkNote.encodeTo('/'+ p.getUrl(), p.getFullDisplayName()) );
+                                        future.cancel(true);
+                                        throw x; // rethrow so that the triggering project get flagged as cancelled
+                                    }
+
                                     listener.getLogger().println(HyperlinkNote.encodeTo('/' + startedRun.getUrl(), startedRun.getFullDisplayName()) + " started.");
 
                                     Run completedRun = future.get();


### PR DESCRIPTION
Cancel triggered build on InterruptException

When a triggering project is cancelled by interrupting its Executor thread and a triggered project is waiting in the build queue (via `waitForStart()`) the InterruptedException is not handled.  The tiggered project is properly cancelled, but the triggering project is left in the queue and will eventually run when a slot is available.

Catch InterruptException while waiting for the triggered project to start and cancel the queued run.

Stacktrace with parameterized-trigger-2.44:

```
org.jenkinsci.plugins.postbuildscript.PostBuildScriptException: java.lang.InterruptedException
    at org.jenkinsci.plugins.postbuildscript.processor.Processor.processBuildSteps(Processor.java:190)
    at org.jenkinsci.plugins.postbuildscript.processor.Processor.processScripts(Processor.java:91)
    at org.jenkinsci.plugins.postbuildscript.processor.Processor.process(Processor.java:79)
    at org.jenkinsci.plugins.postbuildscript.processor.Processor.process(Processor.java:73)
    at org.jenkinsci.plugins.postbuildscript.PostBuildScript.perform(PostBuildScript.java:116)
    at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
    at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:803)
    at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:752)
    at hudson.model.Build$BuildExecution.post2(Build.java:177)
    at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:697)
    at hudson.model.Run.execute(Run.java:1932)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:97)
    at hudson.model.Executor.run(Executor.java:429)
Caused by: java.lang.InterruptedException
    at java.base/java.lang.Object.wait(Native Method)
    at java.base/java.lang.Object.wait(Object.java:328)
    at hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:79)
    at hudson.model.queue.FutureImpl.waitForStart(FutureImpl.java:68)
    at hudson.plugins.parameterizedtrigger.TriggerBuilder.perform(TriggerBuilder.java:146)
    at org.jenkinsci.plugins.postbuildscript.processor.Processor.processBuildSteps(Processor.java:180)
    ... 13 more
``` 

Reference: https://phabricator.wikimedia.org/T282893

### Testing done

I merely wrote a unit test which interrupts the triggering project and assert the triggered downstream project get cancelled.I am most certainly going to deploy the proposed fix to our production.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
