### PR TITLE
Fix javadoc warning

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
@@ -68,7 +68,7 @@ public class ParameterizedTriggerUtils {
     }
     
     /**
-     * {@link} read VirtualFile
+     * Read VirtualFile.
      * 
      * @param f file to read
      * @return read string


### PR DESCRIPTION
## Fix javadoc warning

Fix a javadoc warning by removing an empty link.

### Testing done

Confirmed the Javadoc warning was visible before this change and that it is not visible after the change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
