### PR TITLE
Remove redundant spotbugs setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
     <gitHubRepo>jenkinsci/parameterized-trigger-plugin</gitHubRepo>
     <jenkins.version>2.387.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
-    <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 </project>


### PR DESCRIPTION
## Remove redundant spotbugs setting

The spotbugs configuration in the parent pom will fail on error.  No need to set it in the pom of the plugin.

### Testing done

Confirmed that plugin compilation runs as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
