### PR TITLE
Do not warn when triggered job is a success

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -187,11 +187,8 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
                                     if (buildStepResult
                                             && config.getBlock().mapBuildStepResult(completedRun.getResult())) {
                                         Result r = config.getBlock().mapBuildResult(completedRun.getResult());
-                                        if (r != null) {
+                                        if (r != null) { // The blocking job is not a success
                                             build.setResult(r);
-                                        } else {
-                                            LOGGER.warning("Attempting to use the result of unfinished build "
-                                                    + completedRun.toString());
                                         }
                                     } else {
                                         buildStepResult = false;


### PR DESCRIPTION
I keep having log messages such as:

  WARNING: [hudson.plugins.parameterizedtrigger.TriggerBuilder perform]
  Attempting to use the result of unfinished build <name of job> #1234

The message was introduced in #161 by 06d8f19218 but in #148 / 02ee6ea5, mapBuildResult() was made to return `null` by default (eg on SUCCESS).

The resut is the warning is always triggered when the triggered build succeeds.

Fixes https://phabricator.wikimedia.org/T336782

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
