### PR TITLE
Bump promoted-builds optional dependency to 892.vd6219fc0a_efb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    ignore:
+      # Fails plugin bill of materials tests
+      # https://github.com/jenkinsci/bom/issues/3171
+      - dependency-name: "org.jenkins-ci.plugins:promoted-builds"
     labels:
       - "dependencies"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.81</version>
+    <version>4.82</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,18 +64,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>3.11</version>
+      <version>892.vd6219fc0a_efb</version>
       <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guice</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/parameterized-trigger-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
@@ -43,8 +43,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>3023.v02a_987a_b_3ff9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Bump promoted-builds optional dependency to 892.vd6219fc0a_efb

892.vd6219fc0a_efb was released 2 years ago.  Over 50% of all installations of the promoted builds plugin are already using 892.vd6219fc0a_efb or newer.  Those users will see no difference from this change, since they are already using 892.vd6219fc0a_efb.

Recent Jenkins versions will display broken icons with older versions of the promoted builds plugin.  Fixed in https://github.com/jenkinsci/promoted-builds-plugin/pull/170 as part of 873.v6149db_d64130.  Upgrading to 892.vd6219fc0a_efb will fix that issue for users.

[Installation statistics](https://stats.jenkins.io/pluginversions//parameterized-trigger.html) show that 892.vd6219fc0a_efb is the second most popular release.  It is second only to the most recent release, 945.v597f5c6a_d3fd.  A step towards eventually upgrading the promoted-builds optional dependency that is part of the git plugin.  Attempts to update that optional dependency have shown consistent failures in the plugin bill of materials.

* https://github.com/jenkinsci/bom/pull/3170
* https://github.com/jenkinsci/bom/pull/2809

Bumps [promoted-builds](https://github.com/jenkinsci/promoted-builds-plugin) from 3.11 to 892.vd6219fc0a_efb
- [Release notes](https://github.com/jenkinsci/promoted-builds-plugin/releases/tag/892.vd6219fc0a_efb)

Also removes unnecessary exclusions.

Also upgrades to the most recent parent pom.

Also requires Jenkins 2.426.3 or newer because [installation statistics](https://stats.jenkins.io/pluginversions/parameterized-trigger.html) show that 80% of the installations of 787.v665fcf2a_830b_ release (6 months old) are already running Jenkins 2.426.3.

[SECURITY-3314](https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314) advises users to upgrade to Jenkins 2.426.3 or newer to resolve a critical security vulnerability.

### Testing done

Rely on ci.jenkins.io and on a pull request to the plugin bill of materials to check the upgrade.

Testing in plugin bill of materials with:

* https://github.com/jenkinsci/bom/pull/3172

Test uses builds from this pull request and from a matching git plugin pull request:

* https://github.com/jenkinsci/git-plugin/pull/1581

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
