### PR TITLE
Fix javadoc warnings

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildInfoExporterAction.java
@@ -243,7 +243,7 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
      * Handle cases from older builds so that they still add old variables if
      * needed to. Should not show any UI as there will be no data added.
      *
-     * @return
+     * @return object extracted from old data
      */
     public Object readResolve() {
         if (this.lastReference == null) {
@@ -288,7 +288,7 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
     /**
      * Get a list of projects as a string using the separator
      *
-     * @param separator
+     * @param separator string to separate the list of projects
      * @return list of projects separated by separator
      */
     protected String getProjectListString(String separator) {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/BuildTriggerConfig.java
@@ -848,8 +848,9 @@ public class BuildTriggerConfig implements Describable<BuildTriggerConfig> {
          *
          * Copied from hudson.tasks.BuildTrigger.doAutoCompleteChildProjects(String value)
          *
-         * @param value
-         * @return
+         * @param value String provided by the user for autocompletion
+         * @param context Context of the autocompletion request
+         * @return candidates for autocompletion
          */
         public AutoCompletionCandidates doAutoCompleteProjects(
                 @QueryParameter String value, @AncestorInPath ItemGroup context) {

--- a/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/ParameterizedTriggerUtils.java
@@ -44,7 +44,7 @@ public class ParameterizedTriggerUtils {
     /**
      * Load properties from string.
      *
-     * @throws IOException
+     * @throws IOException on IO error
      */
     public static Properties loadProperties(String properties) throws IOException {
         Properties p = new Properties();
@@ -58,7 +58,7 @@ public class ParameterizedTriggerUtils {
      * @param f file to read
      * @param encoding null for platform default encoding.
      * @return read string
-     * @throws IOException
+     * @throws IOException on IO error
      */
     public static String readFileToString(FilePath f, String encoding) throws IOException, InterruptedException {
         try (InputStream in = f.read()) {
@@ -71,7 +71,7 @@ public class ParameterizedTriggerUtils {
      *
      * @param f file to read
      * @return read string
-     * @throws IOException
+     * @throws IOException on IO error
      */
     public static String readFileToString(VirtualFile f) throws IOException, InterruptedException {
         try (InputStream in = f.open()) {


### PR DESCRIPTION
## Fix javadoc warnings

While releasing the most recent version, there were javadoc warnings reported in the build log.  Fix those javadoc warnings.

### Testing done

Confirmed that Javadoc warnings are no longer visible after these changes.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
