### PR TITLE
Handle NOT_BUILT and ABORTED as other results

### DIFF
--- a/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
+++ b/src/main/java/hudson/plugins/parameterizedtrigger/TriggerBuilder.java
@@ -178,18 +178,19 @@ public class TriggerBuilder extends Builder implements DependencyDeclarer {
                                                 + " started.");
 
                                 Run completedRun = future.get();
+                                Result completedResult = completedRun.getResult();
                                 listener.getLogger()
                                         .println(HyperlinkNote.encodeTo(
                                                         '/' + completedRun.getUrl(), completedRun.getFullDisplayName())
-                                                + " completed. Result was " + completedRun.getResult());
+                                                + " completed. Result was " + completedResult);
                                 BuildInfoExporterAction.addBuildInfoExporterAction(
                                         build,
                                         completedRun.getParent().getFullName(),
                                         completedRun.getNumber(),
-                                        completedRun.getResult());
+                                        completedResult);
 
-                                if (buildStepResult && config.getBlock().mapBuildStepResult(completedRun.getResult())) {
-                                    Result r = config.getBlock().mapBuildResult(completedRun.getResult());
+                                if (buildStepResult && config.getBlock().mapBuildStepResult(completedResult)) {
+                                    Result r = config.getBlock().mapBuildResult(completedResult);
                                     if (r != null) { // The blocking job is not a success
                                         build.setResult(r);
                                     }

--- a/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/test/TriggerBuilderTest.java
@@ -248,6 +248,38 @@ class TriggerBuilderTest {
     }
 
     @Test
+    void testCancelledFromBuildQueue(JenkinsRule r) throws Exception {
+        r.jenkins.setNumExecutors(1); // the downstream-project would be in the build queue
+
+        FreeStyleProject triggerProject = r.createFreeStyleProject("upstream-project");
+        FreeStyleProject downstreamProject = r.createFreeStyleProject("downstream-project");
+
+        TriggerBuilder triggerBuilder = new TriggerBuilder(createTriggerConfig("downstream-project"));
+
+        triggerProject.getBuildersList().add(triggerBuilder);
+        QueueTaskFuture<FreeStyleBuild> parentBuild = triggerProject.scheduleBuild2(0);
+
+        parentBuild.waitForStart();
+        Thread.sleep(500);
+
+        assertEquals(1, r.jenkins.getQueue().countBuildableItems(), "Downstream project is in build queue");
+
+        // Cancel the queued build
+        r.jenkins.getQueue().clear();
+        parentBuild.get();
+
+        assertLines(
+                triggerProject.getLastBuild(),
+                "Waiting for the completion of downstream-project",
+                "Not built: downstream-project has been cancelled while waiting in the queue.",
+                // The test class configures the BlockingBehaviour to never
+                // fail and that includes cancelled job.
+                "Finished: SUCCESS");
+        assertNull(downstreamProject.getLastBuild(), "No downstream build has been run");
+        assertEquals(0, r.jenkins.getQueue().countBuildableItems(), "No build left in queue");
+    }
+
+    @Test
     void testConsoleOutputWithCounterParameters(JenkinsRule r) throws Exception {
         r.createFreeStyleProject("project1");
         r.createFreeStyleProject("project2");


### PR DESCRIPTION
Use case
--------

My use case is a post build script triggering a job which does not need to fully complete. Since the build step can be cancelled while waiting or building, it causes the triggering build to be marked as a failure despite asking to never block.

To fix that, I need the plugin to pass the result of the build step through `BlockingBehaviour`. That lets one define how to behave when the triggered build is `NOT_BUILT` (it got cancelled frmo the queue). In my case I need it to never block.

See: https://phabricator.wikimedia.org/T352319

Solution
--------

There are multiple reasons for a job to not fully complete:

- it is interrupted, an InterruptedException is thrown, this is still rethrown and Jenkins will mark the build as `ABORTED`.

- it can be cancelled from the build queue raising a `CancellationException`. This previously raised an `AbortException` which Jenkins handles by marking the build as a failure. I have changed it to a `NOT_BUILT` result which can be process as other results (addressing  my use case to have it to never block).

The Jenkins Result class ranks the results as:
- `SUCCESS`
- `UNSTABLE`
- `FAILURE`
- `NOT_BUILT`
- `ABORTED`.

The `NOT_BUILT` and `ABORTED` results are thus worse than a `FAILURE` and would be matched as such in `BlockingBehavior` `mapBuildStepResult()` and `mapBuildResult()` which both use `isWorseOrEqualTo()` for comparison.

Add a test `testCancelledFromBuildQueue()` to cover the `CancellationException()` is caught and it results in a `SUCCESS` (since the test blocking behavior is to never block).

The `ResultConditionTest` test covers that `BlockingBehavior` is able to map `NOT_BUILD` and `ABORTED` since it has two tests explicitly cancelling and interrupting jobs.

Examples
--------

When a build is ongoing and when aborting it:
```
  Waiting for the completion of downstream-project
  downstream-project #7 started.
  downstream-project #7 completed. Result was ABORTED
  Build step 'Trigger/call builds on other projects' marked build as failure
  Finished: FAILURE
```

When it is waiting in the build queue and get cancelled:
```
  Waiting for the completion of downstream-project
  Not built: downstream-project has been cancelled while waiting in the queue.
  Build step 'Trigger/call builds on other projects' marked build as failure
  Finished: FAILURE
```


### Testing done

I have created two jobs in a Jenkins spinned up with `mvn hpi:run`. I have covered the behavior for cancelled jobs with a new test `TriggerBuilderTest.testCancelledFromBuildQueue()`.

The result mapping for `ABORTED` and `NOT_BUILD` is already covered by `ResultConditionTest`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch! _I have used a branch named `handle-not_built-canceled`_
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

