### PR TITLE
[JENKINS-75465] RunIdMigrator deleted - update build dirs from datetime to numeric

### DIFF
--- a/src/test/resources/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest/testMigrateFrom221/jobs/downstream1/builds/1/build.xml
+++ b/src/test/resources/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest/testMigrateFrom221/jobs/downstream1/builds/1/build.xml
@@ -5,7 +5,7 @@
       <parameters>
         <hudson.model.StringParameterValue>
           <name>test</name>
-          <value>test3</value>
+          <value>test1</value>
         </hudson.model.StringParameterValue>
       </parameters>
     </hudson.model.ParametersAction>
@@ -23,9 +23,9 @@
       </causes>
     </hudson.model.CauseAction>
   </actions>
-  <number>2</number>
+  <timestamp>1386004362000</timestamp>
   <result>SUCCESS</result>
-  <duration>31</duration>
+  <duration>178</duration>
   <charset>UTF-8</charset>
   <keepLog>false</keepLog>
   <builtOn></builtOn>

--- a/src/test/resources/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest/testMigrateFrom221/jobs/downstream1/builds/2/build.xml
+++ b/src/test/resources/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest/testMigrateFrom221/jobs/downstream1/builds/2/build.xml
@@ -5,7 +5,7 @@
       <parameters>
         <hudson.model.StringParameterValue>
           <name>test</name>
-          <value>test1</value>
+          <value>test3</value>
         </hudson.model.StringParameterValue>
       </parameters>
     </hudson.model.ParametersAction>
@@ -23,9 +23,9 @@
       </causes>
     </hudson.model.CauseAction>
   </actions>
-  <number>1</number>
+  <timestamp>1386004363000</timestamp>
   <result>SUCCESS</result>
-  <duration>178</duration>
+  <duration>31</duration>
   <charset>UTF-8</charset>
   <keepLog>false</keepLog>
   <builtOn></builtOn>

--- a/src/test/resources/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest/testMigrateFrom221/jobs/upstream/builds/1/build.xml
+++ b/src/test/resources/hudson/plugins/parameterizedtrigger/test/BuildInfoExporterTest/testMigrateFrom221/jobs/upstream/builds/1/build.xml
@@ -37,7 +37,7 @@
       <lastReference reference="../buildRefs/entry[2]/list/hudson.plugins.parameterizedtrigger.BuildInfoExporterAction_-BuildReference[2]"/>
     </hudson.plugins.parameterizedtrigger.BuildInfoExporterAction>
   </actions>
-  <number>1</number>
+  <timestamp>1386004362000</timestamp>
   <result>SUCCESS</result>
   <duration>1503</duration>
   <charset>UTF-8</charset>


### PR DESCRIPTION
With https://github.com/jenkinsci/jenkins/pull/10521 `RunIdMigrator` is being removed. It was converting the old build directory formatted `yyyy-MM-dd_HH-mm-ss` to numeric during runtime.

After the migrator is removed, the test will fail if the build directory is still named in old format.

This is noticed in the bom-weekly testing at:- [PR](https://github.com/jenkinsci/jenkins/pull/10521) and [test failure log](https://ci.jenkins.io/job/Tools/job/bom/job/PR-4888/2/testReport/hudson.plugins.parameterizedtrigger.test/BuildInfoExporterTest/pct_parameterized_trigger_plugin_weekly___testMigrateFrom221/)

This PR updates the,
* build directory name to numerical name
* `build.xml` is updated accordingly: removed `<number>` tag, added `<timestamp>` tag of the corresponding time of previous build directory name.

This PR will help with the downstream RunIdMigrator deletion work.

### Testing done
* Reproduced the failure in local with incremental Jenkins core build; fixed the test and verified it works.
  ```bash
  mvn test \
  -Dtest=hudson.plugins.parameterizedtrigger.test.BuildInfoExporterTest#testMigrateFrom221 \
  -Djenkins.version=2.505-rc36606.6430fb_c214b_d
  ```

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
