### PR TITLE
Adapt CapturedEnvironmentActionTest to Jenkins 2.563 OldDataMonitor

### DIFF
--- a/src/test/java/hudson/plugins/parameterizedtrigger/CapturedEnvironmentActionTest.java
+++ b/src/test/java/hudson/plugins/parameterizedtrigger/CapturedEnvironmentActionTest.java
@@ -16,6 +16,7 @@ import hudson.diagnosis.OldDataMonitor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Saveable;
+import hudson.util.VersionNumber;
 import java.io.File;
 import java.net.URL;
 import java.util.Map;
@@ -51,13 +52,15 @@ class CapturedEnvironmentActionTest {
         FreeStyleProject triggering = r.jenkins.getItem("triggering", r.jenkins, FreeStyleProject.class);
         FreeStyleBuild build = triggering.getLastBuild();
 
-        assertTrue(monitor.isActivated(), "OldDataMonitor should be active.");
         Map<Saveable, OldDataMonitor.VersionRange> data = monitor.getData();
-        assertThat(
-                data,
-                hasEntry(
-                        sameInstance(build),
-                        new HasExtra(containsString("AssertionError: " + CapturedEnvironmentAction.OLD_DATA_MESSAGE))));
+        if (r.jenkins.getVersion().isOlderThan(new VersionNumber("2.563"))) {
+            // Jenkins 2.563 and later do not save Runs in OldDataMonitor
+            // Pull request https://github.com/jenkinsci/jenkins/pull/26711
+            // TODO Remove this block when minimum Jenkins version is more than 2.563
+            assertTrue(monitor.isActivated(), "OldDataMonitor should be active.");
+            String expected = "AssertionError: " + CapturedEnvironmentAction.OLD_DATA_MESSAGE;
+            assertThat(data, hasEntry(sameInstance(build), new HasExtra(containsString(expected))));
+        }
 
         build.save();
         data = monitor.getData();


### PR DESCRIPTION
## Adapt CapturedEnvironmentActionTest to Jenkins 2.563 OldDataMonitor

Jenkins 2.563 and later do not include Run's in the OldDataMonitor.  More details are available in pull request:

* https://github.com/jenkinsci/jenkins/pull/26711

This test asserted that Run data was included in the OldDataMonitor.  That is no longer the case, so the assertion is not useful.

### Testing done

* Confirmed the test continues to pass with Jenkins 2.562
* Confirmed that the test now passes with Jenkins 2.563

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
